### PR TITLE
feat: structured JSON logging with named processes and gRPC instrumentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ Thumbs.db
 .bsr_token_secret
 
 /scripts
+/.thoughts

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ license = "MIT"
 tokio = { version = "1.40", features = ["full"] }
 tokio-util = "0.7"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 anyhow = "1.0"
 thiserror = "1.0"
 prost = "0.13"

--- a/crates/analytics_worker/src/nats/processed_envelope_producer.rs
+++ b/crates/analytics_worker/src/nats/processed_envelope_producer.rs
@@ -16,8 +16,9 @@ pub struct ProcessedEnvelopeProducer {
 impl ProcessedEnvelopeProducer {
     pub fn new(jetstream: Arc<dyn JetStreamPublisher>, base_subject: String) -> Self {
         info!(
-            "Created ProcessedEnvelopeProducer with base subject: {}",
-            base_subject
+            stream = "processed_envelopes",
+            base_subject = %base_subject,
+            "Initialized ProcessedEnvelopeProducer"
         );
         Self {
             jetstream,

--- a/crates/cdc_worker/src/domain/process.rs
+++ b/crates/cdc_worker/src/domain/process.rs
@@ -34,8 +34,8 @@ impl CdcProcess {
 
     pub async fn run(self) -> Result<()> {
         info!(
-            "Starting CDC process with {} entity configurations",
-            self.entity_configs.len()
+            entity_count = self.entity_configs.len(),
+            "Starting CDC process"
         );
 
         // Create NATS publisher
@@ -87,12 +87,12 @@ impl CdcProcess {
                         info!("CDC pipeline started, waiting for completion");
                         // Wait for pipeline to complete
                         if let Err(e) = pipeline.wait().await {
-                            error!("CDC pipeline error: {}", e);
+                            error!(error = %e, "CDC pipeline error");
                             return Err(e.into());
                         }
                     }
                     Err(e) => {
-                        error!("CDC pipeline start error: {}", e);
+                        error!(error = %e, "CDC pipeline start error");
                         return Err(e.into());
                     }
                 }

--- a/crates/cdc_worker/src/nats/nats_sink.rs
+++ b/crates/cdc_worker/src/nats/nats_sink.rs
@@ -50,9 +50,9 @@ impl NatsSink {
             .collect();
 
         info!(
-            "Initialized NatsSink with {} entity configurations: {:?}",
-            configs_by_name.len(),
-            configs_by_name.keys().collect::<Vec<_>>()
+            entity_count = configs_by_name.len(),
+            entities = ?configs_by_name.keys().collect::<Vec<_>>(),
+            "Initialized NatsSink for CDC events"
         );
 
         Self {

--- a/crates/common/src/nats/client.rs
+++ b/crates/common/src/nats/client.rs
@@ -12,7 +12,7 @@ pub struct NatsClient {
 
 impl NatsClient {
     pub async fn connect(url: &str, timeout: std::time::Duration) -> Result<Self> {
-        info!("Connecting to NATS at {} (timeout={:?})", url, timeout);
+        info!(url = %url, timeout_ms = timeout.as_millis(), "Connecting to NATS");
 
         // Configure connection timeout for establishing the TCP connection
         let client = async_nats::ConnectOptions::new()
@@ -28,7 +28,7 @@ impl NatsClient {
     }
 
     pub async fn ensure_stream(&self, stream_name: &str) -> Result<()> {
-        info!("Ensuring stream '{}' exists", stream_name);
+        info!(stream = %stream_name, "Ensuring stream exists");
 
         let stream_config = StreamConfig {
             name: stream_name.to_string(),
@@ -39,14 +39,14 @@ impl NatsClient {
 
         match self.jetstream.get_stream(stream_name).await {
             Ok(_) => {
-                info!("Stream '{}' already exists", stream_name);
+                info!(stream = %stream_name, "Stream already exists");
             }
             Err(_) => {
                 self.jetstream
                     .create_stream(stream_config)
                     .await
                     .context("Failed to create stream")?;
-                info!("Created stream '{}'", stream_name);
+                info!(stream = %stream_name, "Created stream");
             }
         }
 
@@ -137,7 +137,7 @@ impl PullConsumer for NatsPullConsumer {
             match msg {
                 Ok(message) => result.push(message),
                 Err(e) => {
-                    error!("Error receiving message: {}", e);
+                    error!(error = %e, "Error receiving message");
                     // Continue processing other messages
                 }
             }

--- a/crates/gateway_orchestrator/src/nats/raw_envelope_producer.rs
+++ b/crates/gateway_orchestrator/src/nats/raw_envelope_producer.rs
@@ -17,8 +17,9 @@ pub struct RawEnvelopeProducer {
 impl RawEnvelopeProducer {
     pub fn new(jetstream: Arc<dyn JetStreamPublisher>, base_subject: String) -> Self {
         info!(
-            "Created RawEnvelopeProducer with base subject: {}",
-            base_subject
+            stream = "raw_envelopes",
+            base_subject = %base_subject,
+            "Initialized RawEnvelopeProducer"
         );
         Self {
             jetstream,

--- a/crates/ponix_api/src/grpc/device_handler.rs
+++ b/crates/ponix_api/src/grpc/device_handler.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 use tonic::{Request, Response, Status};
-use tracing::{debug, info};
+use tracing::{info, instrument};
 
 use crate::domain::DeviceService;
 use ponix_proto_prost::end_device::v1::{
@@ -28,17 +28,19 @@ impl DeviceServiceHandler {
 
 #[tonic::async_trait]
 impl DeviceServiceTrait for DeviceServiceHandler {
+    #[instrument(
+        name = "CreateEndDevice",
+        skip(self, request),
+        fields(
+            organization_id = %request.get_ref().organization_id,
+            device_name = %request.get_ref().name
+        )
+    )]
     async fn create_end_device(
         &self,
         request: Request<CreateEndDeviceRequest>,
     ) -> Result<Response<CreateEndDeviceResponse>, Status> {
         let req = request.into_inner();
-
-        debug!(
-            organization_id = %req.organization_id,
-            name = %req.name,
-            "Received CreateDevice request"
-        );
 
         // Convert proto → domain
         let input = to_create_device_input(req);
@@ -60,13 +62,16 @@ impl DeviceServiceTrait for DeviceServiceHandler {
         }))
     }
 
+    #[instrument(
+        name = "GetEndDevice",
+        skip(self, request),
+        fields(device_id = %request.get_ref().device_id)
+    )]
     async fn get_end_device(
         &self,
         request: Request<GetEndDeviceRequest>,
     ) -> Result<Response<GetEndDeviceResponse>, Status> {
         let req = request.into_inner();
-
-        debug!(device_id = %req.device_id, "Received GetDevice request");
 
         // Convert proto → domain
         let input = to_get_device_input(req);
@@ -86,13 +91,16 @@ impl DeviceServiceTrait for DeviceServiceHandler {
         }))
     }
 
+    #[instrument(
+        name = "ListEndDevices",
+        skip(self, request),
+        fields(organization_id = %request.get_ref().organization_id)
+    )]
     async fn list_end_devices(
         &self,
         request: Request<ListEndDevicesRequest>,
     ) -> Result<Response<ListEndDevicesResponse>, Status> {
         let req = request.into_inner();
-
-        debug!(organization_id = %req.organization_id, "Received ListDevices request");
 
         // Convert proto → domain
         let input = to_list_devices_input(req);

--- a/crates/ponix_api/src/grpc/organization_handler.rs
+++ b/crates/ponix_api/src/grpc/organization_handler.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 use tonic::{Request, Response, Status};
-use tracing::{debug, info};
+use tracing::{info, instrument};
 
 use crate::domain::OrganizationService;
 use ponix_proto_prost::organization::v1::{
@@ -29,13 +29,16 @@ impl OrganizationServiceHandler {
 
 #[tonic::async_trait]
 impl OrganizationServiceTrait for OrganizationServiceHandler {
+    #[instrument(
+        name = "CreateOrganization",
+        skip(self, request),
+        fields(organization_name = %request.get_ref().name)
+    )]
     async fn create_organization(
         &self,
         request: Request<CreateOrganizationRequest>,
     ) -> Result<Response<CreateOrganizationResponse>, Status> {
         let req = request.into_inner();
-
-        debug!(name = %req.name, "Received CreateOrganization request");
 
         // Convert proto → domain
         let input = to_create_organization_input(req);
@@ -62,13 +65,16 @@ impl OrganizationServiceTrait for OrganizationServiceHandler {
         }))
     }
 
+    #[instrument(
+        name = "GetOrganization",
+        skip(self, request),
+        fields(organization_id = %request.get_ref().organization_id)
+    )]
     async fn get_organization(
         &self,
         request: Request<GetOrganizationRequest>,
     ) -> Result<Response<GetOrganizationResponse>, Status> {
         let req = request.into_inner();
-
-        debug!(organization_id = %req.organization_id, "Received GetOrganization request");
 
         // Convert proto → domain
         let input = to_get_organization_input(req);
@@ -88,13 +94,16 @@ impl OrganizationServiceTrait for OrganizationServiceHandler {
         }))
     }
 
+    #[instrument(
+        name = "DeleteOrganization",
+        skip(self, request),
+        fields(organization_id = %request.get_ref().organization_id)
+    )]
     async fn delete_organization(
         &self,
         request: Request<DeleteOrganizationRequest>,
     ) -> Result<Response<DeleteOrganizationResponse>, Status> {
         let req = request.into_inner();
-
-        debug!(organization_id = %req.organization_id, "Received DeleteOrganization request");
 
         // Convert proto → domain
         let input = to_delete_organization_input(req);

--- a/crates/ponix_api/src/grpc/server.rs
+++ b/crates/ponix_api/src/grpc/server.rs
@@ -60,7 +60,21 @@ pub async fn run_grpc_server(
         .parse()
         .expect("Invalid server address");
 
-    info!("Starting gRPC server on {}", addr);
+    info!(address = %addr, "Starting gRPC server");
+
+    // Log registered routes
+    info!("Registered gRPC routes:");
+    info!("  POST /ponix.end_device.v1.EndDeviceService/CreateEndDevice");
+    info!("  POST /ponix.end_device.v1.EndDeviceService/GetEndDevice");
+    info!("  POST /ponix.end_device.v1.EndDeviceService/ListEndDevices");
+    info!("  POST /ponix.organization.v1.OrganizationService/CreateOrganization");
+    info!("  POST /ponix.organization.v1.OrganizationService/GetOrganization");
+    info!("  POST /ponix.organization.v1.OrganizationService/DeleteOrganization");
+    info!("  POST /ponix.gateway.v1.GatewayService/CreateGateway");
+    info!("  POST /ponix.gateway.v1.GatewayService/GetGateway");
+    info!("  POST /ponix.gateway.v1.GatewayService/ListGateways");
+    info!("  POST /ponix.gateway.v1.GatewayService/UpdateGateway");
+    info!("  POST /ponix.gateway.v1.GatewayService/DeleteGateway");
 
     // Create handlers
     let device_handler = DeviceServiceHandler::new(device_service);

--- a/docker/docker-compose.service.yaml
+++ b/docker/docker-compose.service.yaml
@@ -8,10 +8,10 @@ services:
     image: ponix-all-in-one:latest
     container_name: ponix-all-in-one
     ports:
-      - "50051:50051"   # gRPC server
+      - "50051:50051" # gRPC server
     environment:
       # Service configuration
-      PONIX_LOG_LEVEL: debug
+      PONIX_LOG_LEVEL: info
       PONIX_MESSAGE: "Hello from ponix-rs!"
       PONIX_INTERVAL_SECS: "3"
       PONIX_STARTUP_TIMEOUT_SECS: "30"


### PR DESCRIPTION
## Summary

Implements structured JSON logging across the codebase as specified in Issue #55. This provides machine-readable logs with consistent field naming for better observability.

### Key Changes

- **JSON Logging Infrastructure**: Updated `tracing-subscriber` to output JSON format with span lists for request correlation
- **Runner Lifecycle Logging**: Added "Hello!" and "Goodbye!" messages with named processes (`ponix_api`, `gateway_orchestrator`, `cdc_worker`, `analytics_worker_*`)
- **NATS Infrastructure Logging**: Consistent `stream`, `consumer`, `filter_subject` logging at INFO level for all consumers and producers
- **gRPC Request Tracing**: Added `#[instrument]` spans to all handlers with relevant fields (`device_id`, `organization_id`, `gateway_id`)
- **Standardized Field Naming**: Consistent field names across all log entries (`error`, `count`, `stream`, etc.)

### Files Changed

- `Cargo.toml` - Added `json` feature to tracing-subscriber
- `crates/runner/src/lib.rs` - Added `NamedProcess` wrapper and lifecycle logging
- `crates/ponix_all_in_one/src/main.rs` - JSON subscriber config and named processes
- `crates/common/src/nats/*.rs` - Structured NATS logging
- `crates/ponix_api/src/grpc/*.rs` - `#[instrument]` spans and route logging
- `crates/cdc_worker/src/**/*.rs` - Standardized field naming
- `crates/analytics_worker/src/**/*.rs` - Standardized field naming

### Example Log Output

```json
{"timestamp":"2025-11-26T...","level":"INFO","message":"Hello! Starting application","process_count":4}
{"timestamp":"2025-11-26T...","level":"INFO","message":"Starting process","process":"ponix_api"}
{"timestamp":"2025-11-26T...","level":"INFO","spans":[{"name":"CreateEndDevice","device_id":"..."}],"message":"Device created successfully"}
```

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo test --workspace` passes (177 tests)
- [ ] Manual verification: Start service and verify JSON log output
- [ ] Manual verification: Make gRPC requests and verify span fields appear

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)