### PR TITLE
feat: add ListOrganizations endpoint and improve Tilt configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2750,9 +2750,9 @@ dependencies = [
 
 [[package]]
 name = "ponix_ponix_community_neoeinstein-prost"
-version = "0.4.0-20251129185957-8f22d4974be0.1"
+version = "0.4.0-20251130212524-fb4fe527b8d9.1"
 source = "sparse+https://buf.build/gen/cargo/"
-checksum = "44fc54472072c072c3f9c29f4aa8ea62ea8be7ae973c2dcf1c604251e3d9e8a7"
+checksum = "086b4753a46e309472816a80e2f684c60456afd90dd2c6c43c0f4a8a244c309c"
 dependencies = [
  "prost",
  "prost-types",
@@ -2760,9 +2760,9 @@ dependencies = [
 
 [[package]]
 name = "ponix_ponix_community_neoeinstein-tonic"
-version = "0.4.1-20251129185957-8f22d4974be0.1"
+version = "0.4.1-20251130212524-fb4fe527b8d9.1"
 source = "sparse+https://buf.build/gen/cargo/"
-checksum = "16350bf73e4320d4f1391d60890e46522351a3c73453231ba4ce62f9847f1590"
+checksum = "6aedb5184c330e0ac0c26e4dcd87b37574bfef9d414fd146d5bd6713cbef89d6"
 dependencies = [
  "ponix_ponix_community_neoeinstein-prost",
  "tonic",
@@ -4976,7 +4976,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/common/src/proto/organization.rs
+++ b/crates/common/src/proto/organization.rs
@@ -1,10 +1,11 @@
 use crate::domain::{
-    CreateOrganizationInput, DeleteOrganizationInput, GetOrganizationInput, Organization,
+    CreateOrganizationInput, DeleteOrganizationInput, GetOrganizationInput,
+    ListOrganizationsInput, Organization,
 };
 use chrono::{DateTime, Utc};
 use ponix_proto_prost::organization::v1::{
     CreateOrganizationRequest, DeleteOrganizationRequest, GetOrganizationRequest,
-    Organization as ProtoOrganization,
+    ListOrganizationsRequest, Organization as ProtoOrganization,
 };
 use prost_types::Timestamp;
 
@@ -47,6 +48,11 @@ pub fn to_delete_organization_input(req: DeleteOrganizationRequest) -> DeleteOrg
     DeleteOrganizationInput {
         organization_id: req.organization_id,
     }
+}
+
+/// Convert protobuf ListOrganizationsRequest to domain ListOrganizationsInput
+pub fn to_list_organizations_input(_req: ListOrganizationsRequest) -> ListOrganizationsInput {
+    ListOrganizationsInput {}
 }
 
 #[cfg(test)]

--- a/crates/ponix_all_in_one/Dockerfile
+++ b/crates/ponix_all_in_one/Dockerfile
@@ -17,7 +17,14 @@ COPY crates ./crates
 COPY .cargo/config.toml ./.cargo/config.toml
 
 # Create recipe (dependency manifest)
-RUN cargo chef prepare --recipe-path recipe.json
+# Needs BSR token to resolve registry dependencies
+RUN --mount=type=secret,id=bsr_token \
+    if [ -f /run/secrets/bsr_token ]; then \
+        export CARGO_REGISTRIES_BUF_TOKEN="Bearer $(cat /run/secrets/bsr_token)" && \
+        cargo chef prepare --recipe-path recipe.json; \
+    else \
+        echo "Error: BSR token secret not found" && exit 1; \
+    fi
 
 # ============================================================================
 # Builder stage - compile dependencies then source


### PR DESCRIPTION
## Summary
- Add `ListOrganizations` gRPC endpoint to query all active organizations
- Fix Dockerfile planner stage to authenticate with BSR registry
- Improve Tiltfile with automatic network creation and resource labels

## Changes
- **ListOrganizations endpoint**: Implements the new `ListOrganizations` RPC defined in the protobuf schema, returning all non-deleted organizations
- **Dockerfile fix**: The planner stage now mounts the BSR token secret so `cargo chef prepare` can resolve registry dependencies
- **Tiltfile improvements**: 
  - Automatically creates the `ponix` Docker network if it doesn't exist
  - Adds labels to organize resources in the Tilt UI (infrastructure, observability, services)
  - Adds resource dependencies to ensure network exists before containers start

## Test plan
- [x] `cargo build --workspace` succeeds
- [x] `cargo test -p ponix_api -p common --lib --features testing` passes
- [x] Verify `ListOrganizations` endpoint works via grpcurl:
  ```bash
  grpcurl -plaintext localhost:50051 organization.v1.OrganizationService/ListOrganizations
  ```
- [x] Verify Tilt starts successfully with `tilt up`

🤖 Generated with [Claude Code](https://claude.com/claude-code)