### PR TITLE
refactor: extract auth into common::auth module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,6 +636,7 @@ name = "common"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "argon2",
  "async-nats",
  "async-trait",
  "bytes",
@@ -645,6 +646,7 @@ dependencies = [
  "futures",
  "goose",
  "http",
+ "jsonwebtoken",
  "mockall",
  "opentelemetry",
  "opentelemetry-appender-tracing",
@@ -2853,10 +2855,8 @@ name = "ponix_api"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "argon2",
  "chrono",
  "common",
- "jsonwebtoken",
  "ponix_ponix_community_neoeinstein-prost",
  "ponix_ponix_community_neoeinstein-tonic",
  "serde",

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -31,6 +31,10 @@ clickhouse.workspace = true
 tokio-postgres.workspace = true
 deadpool-postgres.workspace = true
 
+# Authentication
+argon2.workspace = true
+jsonwebtoken.workspace = true
+
 # OpenTelemetry for trace context propagation and telemetry
 opentelemetry.workspace = true
 opentelemetry_sdk.workspace = true

--- a/crates/common/src/auth.rs
+++ b/crates/common/src/auth.rs
@@ -1,0 +1,9 @@
+mod config;
+mod jwt;
+mod password;
+mod traits;
+
+pub use config::*;
+pub use jwt::*;
+pub use password::*;
+pub use traits::*;

--- a/crates/common/src/auth/config.rs
+++ b/crates/common/src/auth/config.rs
@@ -1,0 +1,15 @@
+/// Configuration for JWT token generation
+#[derive(Debug, Clone)]
+pub struct JwtConfig {
+    pub secret: String,
+    pub expiration_hours: u64,
+}
+
+impl JwtConfig {
+    pub fn new(secret: String, expiration_hours: u64) -> Self {
+        Self {
+            secret,
+            expiration_hours,
+        }
+    }
+}

--- a/crates/common/src/auth/jwt.rs
+++ b/crates/common/src/auth/jwt.rs
@@ -1,0 +1,131 @@
+use crate::auth::{AuthTokenProvider, JwtConfig};
+use crate::domain::{DomainError, DomainResult};
+use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
+use serde::{Deserialize, Serialize};
+
+/// JWT claims structure
+#[derive(Debug, Serialize, Deserialize)]
+pub struct JwtClaims {
+    pub sub: String,  // user_id
+    pub email: String,
+    pub exp: usize,   // expiration timestamp
+    pub iat: usize,   // issued at timestamp
+}
+
+/// JWT-based implementation of AuthTokenProvider
+pub struct JwtAuthTokenProvider {
+    config: JwtConfig,
+}
+
+impl JwtAuthTokenProvider {
+    pub fn new(config: JwtConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl AuthTokenProvider for JwtAuthTokenProvider {
+    fn generate_token(&self, user_id: &str, email: &str) -> DomainResult<String> {
+        let now = chrono::Utc::now();
+        let exp = now + chrono::Duration::hours(self.config.expiration_hours as i64);
+
+        let claims = JwtClaims {
+            sub: user_id.to_string(),
+            email: email.to_string(),
+            exp: exp.timestamp() as usize,
+            iat: now.timestamp() as usize,
+        };
+
+        encode(
+            &Header::default(),
+            &claims,
+            &EncodingKey::from_secret(self.config.secret.as_bytes()),
+        )
+        .map_err(|e| DomainError::RepositoryError(anyhow::anyhow!("JWT encoding error: {}", e)))
+    }
+
+    fn validate_token(&self, token: &str) -> DomainResult<String> {
+        let token_data = decode::<JwtClaims>(
+            token,
+            &DecodingKey::from_secret(self.config.secret.as_bytes()),
+            &Validation::default(),
+        )
+        .map_err(|e| DomainError::InvalidToken(e.to_string()))?;
+
+        Ok(token_data.claims.sub)
+    }
+
+    fn extract_user_id(&self, token: &str) -> Option<String> {
+        // Decode without validation for logging purposes
+        let mut validation = Validation::default();
+        validation.insecure_disable_signature_validation();
+        validation.validate_exp = false;
+
+        decode::<JwtClaims>(
+            token,
+            &DecodingKey::from_secret(&[]),
+            &validation,
+        )
+        .ok()
+        .map(|data| data.claims.sub)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> JwtConfig {
+        JwtConfig::new("test-secret-key".to_string(), 24)
+    }
+
+    #[test]
+    fn test_generate_token_success() {
+        let provider = JwtAuthTokenProvider::new(test_config());
+        let token = provider.generate_token("user-123", "test@example.com");
+        assert!(token.is_ok());
+        assert!(!token.unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_validate_token_success() {
+        let provider = JwtAuthTokenProvider::new(test_config());
+        let token = provider.generate_token("user-123", "test@example.com").unwrap();
+
+        let user_id = provider.validate_token(&token);
+        assert!(user_id.is_ok());
+        assert_eq!(user_id.unwrap(), "user-123");
+    }
+
+    #[test]
+    fn test_validate_token_invalid() {
+        let provider = JwtAuthTokenProvider::new(test_config());
+        let result = provider.validate_token("invalid-token");
+        assert!(matches!(result, Err(DomainError::InvalidToken(_))));
+    }
+
+    #[test]
+    fn test_validate_token_wrong_secret() {
+        let provider1 = JwtAuthTokenProvider::new(test_config());
+        let provider2 = JwtAuthTokenProvider::new(JwtConfig::new("different-secret".to_string(), 24));
+
+        let token = provider1.generate_token("user-123", "test@example.com").unwrap();
+        let result = provider2.validate_token(&token);
+        assert!(matches!(result, Err(DomainError::InvalidToken(_))));
+    }
+
+    #[test]
+    fn test_extract_user_id_success() {
+        let provider = JwtAuthTokenProvider::new(test_config());
+        let token = provider.generate_token("user-123", "test@example.com").unwrap();
+
+        let user_id = provider.extract_user_id(&token);
+        assert_eq!(user_id, Some("user-123".to_string()));
+    }
+
+    #[test]
+    fn test_extract_user_id_invalid_token() {
+        let provider = JwtAuthTokenProvider::new(test_config());
+        let user_id = provider.extract_user_id("invalid-token");
+        assert_eq!(user_id, None);
+    }
+}

--- a/crates/common/src/auth/password.rs
+++ b/crates/common/src/auth/password.rs
@@ -1,0 +1,90 @@
+use crate::auth::PasswordService;
+use crate::domain::{DomainError, DomainResult};
+use argon2::{
+    password_hash::{rand_core::OsRng, PasswordHasher, PasswordVerifier, SaltString},
+    Argon2,
+};
+
+/// Argon2-based implementation of PasswordService
+#[derive(Default)]
+pub struct Argon2PasswordService;
+
+impl Argon2PasswordService {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl PasswordService for Argon2PasswordService {
+    fn hash_password(&self, password: &str) -> DomainResult<String> {
+        let salt = SaltString::generate(&mut OsRng);
+        let argon2 = Argon2::default();
+
+        argon2
+            .hash_password(password.as_bytes(), &salt)
+            .map(|hash| hash.to_string())
+            .map_err(|e| DomainError::PasswordHashingError(e.to_string()))
+    }
+
+    fn verify_password(&self, password: &str, hash: &str) -> DomainResult<bool> {
+        let parsed_hash = argon2::PasswordHash::new(hash)
+            .map_err(|e| DomainError::PasswordHashingError(e.to_string()))?;
+
+        Ok(Argon2::default()
+            .verify_password(password.as_bytes(), &parsed_hash)
+            .is_ok())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hash_password_success() {
+        let service = Argon2PasswordService::new();
+        let hash = service.hash_password("secure-password-123");
+        assert!(hash.is_ok());
+
+        let hash_str = hash.unwrap();
+        assert!(!hash_str.is_empty());
+        assert!(hash_str.starts_with("$argon2"));
+    }
+
+    #[test]
+    fn test_hash_password_different_each_time() {
+        let service = Argon2PasswordService::new();
+        let hash1 = service.hash_password("same-password").unwrap();
+        let hash2 = service.hash_password("same-password").unwrap();
+
+        // Different salts should produce different hashes
+        assert_ne!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_verify_password_correct() {
+        let service = Argon2PasswordService::new();
+        let hash = service.hash_password("secure-password-123").unwrap();
+
+        let result = service.verify_password("secure-password-123", &hash);
+        assert!(result.is_ok());
+        assert!(result.unwrap());
+    }
+
+    #[test]
+    fn test_verify_password_incorrect() {
+        let service = Argon2PasswordService::new();
+        let hash = service.hash_password("correct-password").unwrap();
+
+        let result = service.verify_password("wrong-password", &hash);
+        assert!(result.is_ok());
+        assert!(!result.unwrap());
+    }
+
+    #[test]
+    fn test_verify_password_invalid_hash() {
+        let service = Argon2PasswordService::new();
+        let result = service.verify_password("any-password", "invalid-hash");
+        assert!(matches!(result, Err(DomainError::PasswordHashingError(_))));
+    }
+}

--- a/crates/common/src/auth/traits.rs
+++ b/crates/common/src/auth/traits.rs
@@ -1,0 +1,24 @@
+use crate::domain::DomainResult;
+
+/// Trait for authentication token operations (JWT, cookies, etc.)
+#[cfg_attr(any(test, feature = "testing"), mockall::automock)]
+pub trait AuthTokenProvider: Send + Sync {
+    /// Generate an authentication token for a user
+    fn generate_token(&self, user_id: &str, email: &str) -> DomainResult<String>;
+
+    /// Validate a token and extract the user ID
+    fn validate_token(&self, token: &str) -> DomainResult<String>;
+
+    /// Extract user ID from token without full validation (for logging, etc.)
+    fn extract_user_id(&self, token: &str) -> Option<String>;
+}
+
+/// Trait for password hashing and verification
+#[cfg_attr(any(test, feature = "testing"), mockall::automock)]
+pub trait PasswordService: Send + Sync {
+    /// Hash a plaintext password
+    fn hash_password(&self, password: &str) -> DomainResult<String>;
+
+    /// Verify a password against a hash
+    fn verify_password(&self, password: &str, hash: &str) -> DomainResult<bool>;
+}

--- a/crates/common/src/domain/result.rs
+++ b/crates/common/src/domain/result.rs
@@ -76,6 +76,9 @@ pub enum DomainError {
     #[error("Invalid credentials")]
     InvalidCredentials,
 
+    #[error("Invalid or expired token: {0}")]
+    InvalidToken(String),
+
     #[error("Repository error: {0}")]
     RepositoryError(#[from] anyhow::Error),
 }

--- a/crates/common/src/grpc/error.rs
+++ b/crates/common/src/grpc/error.rs
@@ -46,6 +46,8 @@ pub fn domain_error_to_status(error: DomainError) -> Status {
 
         DomainError::InvalidCredentials => Status::unauthenticated("Invalid email or password"),
 
+        DomainError::InvalidToken(msg) => Status::unauthenticated(format!("Invalid token: {}", msg)),
+
         DomainError::RepositoryError(err) => Status::internal(format!("Internal error: {}", err)),
     }
 }

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod auth;
 pub mod clickhouse;
 pub mod domain;
 pub mod grpc;

--- a/crates/ponix_api/Cargo.toml
+++ b/crates/ponix_api/Cargo.toml
@@ -14,8 +14,6 @@ tokio-util.workspace = true
 chrono.workspace = true
 tonic.workspace = true
 anyhow.workspace = true
-argon2.workspace = true
-jsonwebtoken.workspace = true
 serde.workspace = true
 
 ponix-proto-prost.workspace = true

--- a/crates/ponix_api/src/domain/user_service.rs
+++ b/crates/ponix_api/src/domain/user_service.rs
@@ -1,43 +1,28 @@
-use argon2::{
-    password_hash::{rand_core::OsRng, PasswordHasher, PasswordVerifier, SaltString},
-    Argon2,
-};
+use common::auth::{AuthTokenProvider, PasswordService};
 use common::domain::{
     DomainError, DomainResult, GetUserByEmailInput, GetUserInput, LoginUserInput, LoginUserOutput,
     RegisterUserInput, RegisterUserInputWithId, User, UserRepository,
 };
-use jsonwebtoken::{encode, EncodingKey, Header};
-use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::{debug, instrument};
-
-/// JWT claims structure
-#[derive(Debug, Serialize, Deserialize)]
-pub struct JwtClaims {
-    pub sub: String,  // user_id
-    pub email: String,
-    pub exp: usize,   // expiration timestamp
-    pub iat: usize,   // issued at timestamp
-}
-
-/// Configuration for JWT token generation
-#[derive(Debug, Clone)]
-pub struct JwtConfig {
-    pub secret: String,
-    pub expiration_hours: u64,
-}
 
 /// Domain service for user registration and management
 pub struct UserService {
     user_repository: Arc<dyn UserRepository>,
-    jwt_config: JwtConfig,
+    auth_token_provider: Arc<dyn AuthTokenProvider>,
+    password_service: Arc<dyn PasswordService>,
 }
 
 impl UserService {
-    pub fn new(user_repository: Arc<dyn UserRepository>, jwt_config: JwtConfig) -> Self {
+    pub fn new(
+        user_repository: Arc<dyn UserRepository>,
+        auth_token_provider: Arc<dyn AuthTokenProvider>,
+        password_service: Arc<dyn PasswordService>,
+    ) -> Self {
         Self {
             user_repository,
-            jwt_config,
+            auth_token_provider,
+            password_service,
         }
     }
 
@@ -67,8 +52,8 @@ impl UserService {
             ));
         }
 
-        // Hash the password using Argon2
-        let password_hash = Self::hash_password(&input.password)?;
+        // Hash the password using injected password service
+        let password_hash = self.password_service.hash_password(&input.password)?;
 
         // Generate unique user ID using xid
         let user_id = xid::new().to_string();
@@ -108,17 +93,6 @@ impl UserService {
         Ok(user)
     }
 
-    /// Hash a password using Argon2
-    fn hash_password(password: &str) -> DomainResult<String> {
-        let salt = SaltString::generate(&mut OsRng);
-        let argon2 = Argon2::default();
-
-        argon2
-            .hash_password(password.as_bytes(), &salt)
-            .map(|hash| hash.to_string())
-            .map_err(|e| DomainError::PasswordHashingError(e.to_string()))
-    }
-
     /// Basic email validation
     fn is_valid_email(email: &str) -> bool {
         // Simple validation: contains @ and at least one . after @
@@ -149,72 +123,44 @@ impl UserService {
             .await?
             .ok_or(DomainError::InvalidCredentials)?;
 
-        // Verify password
-        if !Self::verify_password(&input.password, &user.password_hash)? {
+        // Verify password using injected password service
+        if !self.password_service.verify_password(&input.password, &user.password_hash)? {
             return Err(DomainError::InvalidCredentials);
         }
 
-        // Generate JWT token
-        let token = self.generate_jwt(&user)?;
+        // Generate token using injected auth token provider
+        let token = self.auth_token_provider.generate_token(&user.id, &user.email)?;
 
         debug!(user_id = %user.id, "user login successful");
 
         Ok(LoginUserOutput { token })
-    }
-
-    /// Verify a password against its hash using Argon2
-    fn verify_password(password: &str, hash: &str) -> DomainResult<bool> {
-        let parsed_hash = argon2::PasswordHash::new(hash)
-            .map_err(|e| DomainError::PasswordHashingError(e.to_string()))?;
-
-        Ok(Argon2::default()
-            .verify_password(password.as_bytes(), &parsed_hash)
-            .is_ok())
-    }
-
-    /// Generate a JWT token for a user
-    fn generate_jwt(&self, user: &User) -> DomainResult<String> {
-        let now = chrono::Utc::now();
-        let exp = now + chrono::Duration::hours(self.jwt_config.expiration_hours as i64);
-
-        let claims = JwtClaims {
-            sub: user.id.clone(),
-            email: user.email.clone(),
-            exp: exp.timestamp() as usize,
-            iat: now.timestamp() as usize,
-        };
-
-        encode(
-            &Header::default(),
-            &claims,
-            &EncodingKey::from_secret(self.jwt_config.secret.as_bytes()),
-        )
-        .map_err(|e| DomainError::RepositoryError(anyhow::anyhow!("JWT encoding error: {}", e)))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use common::auth::{MockAuthTokenProvider, MockPasswordService};
     use common::domain::MockUserRepository;
-
-    fn test_jwt_config() -> JwtConfig {
-        JwtConfig {
-            secret: "test-secret-key".to_string(),
-            expiration_hours: 24,
-        }
-    }
 
     #[tokio::test]
     async fn test_register_user_success() {
         let mut mock_repo = MockUserRepository::new();
+        let mut mock_password = MockPasswordService::new();
+        let mock_auth = MockAuthTokenProvider::new();
+
+        mock_password
+            .expect_hash_password()
+            .withf(|password: &str| password == "securepassword123")
+            .times(1)
+            .return_once(|_| Ok("hashed-password".to_string()));
 
         mock_repo
             .expect_register_user()
             .withf(|input: &RegisterUserInputWithId| {
                 !input.id.is_empty()
                     && input.email == "test@example.com"
-                    && !input.password_hash.is_empty()
+                    && input.password_hash == "hashed-password"
                     && input.name == "John Doe"
             })
             .times(1)
@@ -229,7 +175,11 @@ mod tests {
                 })
             });
 
-        let service = UserService::new(Arc::new(mock_repo), test_jwt_config());
+        let service = UserService::new(
+            Arc::new(mock_repo),
+            Arc::new(mock_auth),
+            Arc::new(mock_password),
+        );
         let input = RegisterUserInput {
             email: "test@example.com".to_string(),
             password: "securepassword123".to_string(),
@@ -246,7 +196,14 @@ mod tests {
     #[tokio::test]
     async fn test_register_user_invalid_email() {
         let mock_repo = MockUserRepository::new();
-        let service = UserService::new(Arc::new(mock_repo), test_jwt_config());
+        let mock_password = MockPasswordService::new();
+        let mock_auth = MockAuthTokenProvider::new();
+
+        let service = UserService::new(
+            Arc::new(mock_repo),
+            Arc::new(mock_auth),
+            Arc::new(mock_password),
+        );
 
         let input = RegisterUserInput {
             email: "invalid-email".to_string(),
@@ -261,7 +218,14 @@ mod tests {
     #[tokio::test]
     async fn test_register_user_short_password() {
         let mock_repo = MockUserRepository::new();
-        let service = UserService::new(Arc::new(mock_repo), test_jwt_config());
+        let mock_password = MockPasswordService::new();
+        let mock_auth = MockAuthTokenProvider::new();
+
+        let service = UserService::new(
+            Arc::new(mock_repo),
+            Arc::new(mock_auth),
+            Arc::new(mock_password),
+        );
 
         let input = RegisterUserInput {
             email: "test@example.com".to_string(),
@@ -276,7 +240,14 @@ mod tests {
     #[tokio::test]
     async fn test_register_user_empty_name() {
         let mock_repo = MockUserRepository::new();
-        let service = UserService::new(Arc::new(mock_repo), test_jwt_config());
+        let mock_password = MockPasswordService::new();
+        let mock_auth = MockAuthTokenProvider::new();
+
+        let service = UserService::new(
+            Arc::new(mock_repo),
+            Arc::new(mock_auth),
+            Arc::new(mock_password),
+        );
 
         let input = RegisterUserInput {
             email: "test@example.com".to_string(),
@@ -291,7 +262,14 @@ mod tests {
     #[tokio::test]
     async fn test_get_user_empty_id() {
         let mock_repo = MockUserRepository::new();
-        let service = UserService::new(Arc::new(mock_repo), test_jwt_config());
+        let mock_password = MockPasswordService::new();
+        let mock_auth = MockAuthTokenProvider::new();
+
+        let service = UserService::new(
+            Arc::new(mock_repo),
+            Arc::new(mock_auth),
+            Arc::new(mock_password),
+        );
 
         let input = GetUserInput {
             user_id: "".to_string(),
@@ -304,13 +282,19 @@ mod tests {
     #[tokio::test]
     async fn test_get_user_not_found() {
         let mut mock_repo = MockUserRepository::new();
+        let mock_password = MockPasswordService::new();
+        let mock_auth = MockAuthTokenProvider::new();
 
         mock_repo
             .expect_get_user()
             .times(1)
             .return_once(|_| Ok(None));
 
-        let service = UserService::new(Arc::new(mock_repo), test_jwt_config());
+        let service = UserService::new(
+            Arc::new(mock_repo),
+            Arc::new(mock_auth),
+            Arc::new(mock_password),
+        );
         let input = GetUserInput {
             user_id: "nonexistent".to_string(),
         };
@@ -322,19 +306,13 @@ mod tests {
     #[tokio::test]
     async fn test_login_user_success() {
         let mut mock_repo = MockUserRepository::new();
-
-        // Create a valid password hash for "securepassword123"
-        let salt = SaltString::generate(&mut OsRng);
-        let argon2 = Argon2::default();
-        let password_hash = argon2
-            .hash_password(b"securepassword123", &salt)
-            .unwrap()
-            .to_string();
+        let mut mock_password = MockPasswordService::new();
+        let mut mock_auth = MockAuthTokenProvider::new();
 
         let stored_user = User {
             id: "user-123".to_string(),
             email: "test@example.com".to_string(),
-            password_hash: password_hash.clone(),
+            password_hash: "hashed-password".to_string(),
             name: "John Doe".to_string(),
             created_at: Some(chrono::Utc::now()),
             updated_at: Some(chrono::Utc::now()),
@@ -346,7 +324,27 @@ mod tests {
             .times(1)
             .return_once(move |_| Ok(Some(stored_user)));
 
-        let service = UserService::new(Arc::new(mock_repo), test_jwt_config());
+        mock_password
+            .expect_verify_password()
+            .withf(|password: &str, hash: &str| {
+                password == "securepassword123" && hash == "hashed-password"
+            })
+            .times(1)
+            .return_once(|_, _| Ok(true));
+
+        mock_auth
+            .expect_generate_token()
+            .withf(|user_id: &str, email: &str| {
+                user_id == "user-123" && email == "test@example.com"
+            })
+            .times(1)
+            .return_once(|_, _| Ok("jwt-token-123".to_string()));
+
+        let service = UserService::new(
+            Arc::new(mock_repo),
+            Arc::new(mock_auth),
+            Arc::new(mock_password),
+        );
         let input = LoginUserInput {
             email: "test@example.com".to_string(),
             password: "securepassword123".to_string(),
@@ -355,19 +353,25 @@ mod tests {
         let result = service.login_user(input).await;
         assert!(result.is_ok());
         let output = result.unwrap();
-        assert!(!output.token.is_empty());
+        assert_eq!(output.token, "jwt-token-123");
     }
 
     #[tokio::test]
     async fn test_login_user_not_found() {
         let mut mock_repo = MockUserRepository::new();
+        let mock_password = MockPasswordService::new();
+        let mock_auth = MockAuthTokenProvider::new();
 
         mock_repo
             .expect_get_user_by_email()
             .times(1)
             .return_once(|_| Ok(None));
 
-        let service = UserService::new(Arc::new(mock_repo), test_jwt_config());
+        let service = UserService::new(
+            Arc::new(mock_repo),
+            Arc::new(mock_auth),
+            Arc::new(mock_password),
+        );
         let input = LoginUserInput {
             email: "nonexistent@example.com".to_string(),
             password: "somepassword123".to_string(),
@@ -380,18 +384,13 @@ mod tests {
     #[tokio::test]
     async fn test_login_user_wrong_password() {
         let mut mock_repo = MockUserRepository::new();
-
-        let salt = SaltString::generate(&mut OsRng);
-        let argon2 = Argon2::default();
-        let password_hash = argon2
-            .hash_password(b"correctpassword", &salt)
-            .unwrap()
-            .to_string();
+        let mut mock_password = MockPasswordService::new();
+        let mock_auth = MockAuthTokenProvider::new();
 
         let stored_user = User {
             id: "user-123".to_string(),
             email: "test@example.com".to_string(),
-            password_hash,
+            password_hash: "hashed-password".to_string(),
             name: "John Doe".to_string(),
             created_at: Some(chrono::Utc::now()),
             updated_at: Some(chrono::Utc::now()),
@@ -402,7 +401,16 @@ mod tests {
             .times(1)
             .return_once(move |_| Ok(Some(stored_user)));
 
-        let service = UserService::new(Arc::new(mock_repo), test_jwt_config());
+        mock_password
+            .expect_verify_password()
+            .times(1)
+            .return_once(|_, _| Ok(false));
+
+        let service = UserService::new(
+            Arc::new(mock_repo),
+            Arc::new(mock_auth),
+            Arc::new(mock_password),
+        );
         let input = LoginUserInput {
             email: "test@example.com".to_string(),
             password: "wrongpassword123".to_string(),


### PR DESCRIPTION
## Summary

- Extract authentication concerns from `UserService` in `ponix_api` into a dedicated `common::auth` module
- Add `AuthTokenProvider` and `PasswordService` traits for dependency injection
- Implement `JwtAuthTokenProvider` (JWT token generation/validation) and `Argon2PasswordService` (password hashing/verification)
- Refactor `UserService` to accept auth traits via constructor injection
- Add `InvalidToken` error variant to `DomainError` with gRPC mapping
- Remove direct `argon2` and `jsonwebtoken` dependencies from `ponix_api`

## Test plan

- [x] All 230 unit tests pass (`cargo test --workspace --lib --bins`)
- [x] Clippy passes with no warnings (`cargo clippy --workspace`)
- [x] Manual test: Register user via gRPC
- [x] Manual test: Login via gRPC returns JWT token

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)