### PR TITLE
fix: CORS configuration for credentials and cookie handling

### DIFF
--- a/crates/common/src/grpc/cookie.rs
+++ b/crates/common/src/grpc/cookie.rs
@@ -36,11 +36,14 @@ impl RefreshTokenCookie {
             format!("Max-Age={}", self.max_age_seconds),
             format!("Path={}", self.path),
             "HttpOnly".to_string(),
-            "SameSite=None".to_string(),
         ];
 
+        // SameSite=None requires Secure; use Lax for local development (HTTP)
         if self.secure {
+            parts.push("SameSite=None".to_string());
             parts.push("Secure".to_string());
+        } else {
+            parts.push("SameSite=Lax".to_string());
         }
 
         parts.join("; ")
@@ -105,6 +108,8 @@ mod tests {
         assert!(header.contains("refresh_token=token123"));
         assert!(header.contains("HttpOnly"));
         assert!(!header.contains("Secure"));
+        assert!(header.contains("SameSite=Lax"));
+        assert!(!header.contains("SameSite=None"));
     }
 
     #[test]

--- a/crates/common/src/grpc/server.rs
+++ b/crates/common/src/grpc/server.rs
@@ -166,11 +166,13 @@ fn build_cors_layer(config: &CorsConfig) -> CorsLayer {
             HeaderName::from_static("x-user-agent"),
             HeaderName::from_static("grpc-timeout"),
             HeaderName::from_static("authorization"),
+            HeaderName::from_static("cookie"),
         ])
         .expose_headers([
             HeaderName::from_static("grpc-status"),
             HeaderName::from_static("grpc-message"),
             HeaderName::from_static("grpc-status-details-bin"),
+            HeaderName::from_static("set-cookie"),
         ])
         .max_age(Duration::from_secs(config.max_age_secs));
 


### PR DESCRIPTION
## Summary
- Fix CORS configuration to properly support credentials (cookies) with gRPC-Web
- Fix cookie `SameSite` attribute for local development (HTTP requires `Lax`, not `None`)
- Add debug logging for refresh token extraction

## Changes
- **CORS credentials support**: When `allow_credentials` is enabled with wildcard origins, the server now mirrors the request origin instead of using `*` (browsers reject `*` with credentials)
- **Cookie headers**: Added `cookie` to allowed headers and `set-cookie` to exposed headers
- **SameSite cookie fix**: Use `SameSite=Lax` for non-secure (HTTP) environments since `SameSite=None` requires `Secure`
- **Debug logging**: Added logging in refresh endpoint to help diagnose cookie issues

## Test plan
- [ ] Verify gRPC-Web requests from browser include credentials
- [ ] Verify cookies are properly set and sent in local development (HTTP)
- [ ] Verify cookies work in production (HTTPS with `SameSite=None; Secure`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)