### PR TITLE
feat: Add GetUserOrganizations gRPC endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1131,7 +1131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1797,7 +1797,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2873,9 +2873,9 @@ dependencies = [
 
 [[package]]
 name = "ponix_ponix_community_neoeinstein-prost"
-version = "0.5.0-20251206223125-54a23019280d.2"
+version = "0.5.0-20251207171615-b5863031b4f0.2"
 source = "sparse+https://buf.build/gen/cargo/"
-checksum = "1334a4f04117c100fbf760ed8c3859b5d20909b25499c6de318a5aaa3a430f0a"
+checksum = "629f3dd9f8ad0985748280c40af448d3680d67e02d988c0ebe99d6c91d734476"
 dependencies = [
  "prost 0.14.1",
  "prost-types",
@@ -2883,9 +2883,9 @@ dependencies = [
 
 [[package]]
 name = "ponix_ponix_community_neoeinstein-tonic"
-version = "0.5.0-20251206223125-54a23019280d.4"
+version = "0.5.0-20251207171615-b5863031b4f0.4"
 source = "sparse+https://buf.build/gen/cargo/"
-checksum = "193534a4f6bbe4cee0478d9f0167e2d76138f0c2c8c0364266a1938c968753de"
+checksum = "f4707b7843198ce374bd2a405d1e8c4ca383a221046c5ee7b71dfe6758b800fd"
 dependencies = [
  "ponix_ponix_community_neoeinstein-prost",
  "tonic 0.14.2",
@@ -3124,7 +3124,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.35",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -3161,9 +3161,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3465,7 +3465,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/analytics_worker/tests/envelope_integration_test.rs
+++ b/crates/analytics_worker/tests/envelope_integration_test.rs
@@ -10,9 +10,10 @@ mod mocks {
     use async_trait::async_trait;
     use common::domain::{
         CreateDeviceInputWithId, CreateOrganizationInputWithId, DeleteOrganizationInput, Device,
-        DeviceRepository, DomainResult, GetDeviceInput, GetOrganizationInput, ListDevicesInput,
-        ListOrganizationsInput, Organization, OrganizationRepository, ProcessedEnvelope,
-        ProcessedEnvelopeProducer, UpdateOrganizationInput,
+        DeviceRepository, DomainResult, GetDeviceInput, GetOrganizationInput,
+        GetUserOrganizationsInput, ListDevicesInput, ListOrganizationsInput, Organization,
+        OrganizationRepository, ProcessedEnvelope, ProcessedEnvelopeProducer,
+        UpdateOrganizationInput,
     };
     use std::sync::{Arc, Mutex};
 
@@ -97,6 +98,13 @@ mod mocks {
         async fn list_organizations(
             &self,
             _input: ListOrganizationsInput,
+        ) -> DomainResult<Vec<Organization>> {
+            unimplemented!("Not needed for envelope tests")
+        }
+
+        async fn get_organizations_by_user_id(
+            &self,
+            _input: GetUserOrganizationsInput,
         ) -> DomainResult<Vec<Organization>> {
             unimplemented!("Not needed for envelope tests")
         }

--- a/crates/common/src/domain/organization.rs
+++ b/crates/common/src/domain/organization.rs
@@ -51,6 +51,12 @@ pub struct DeleteOrganizationInput {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ListOrganizationsInput {}
 
+/// Input for getting organizations by user ID
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GetUserOrganizationsInput {
+    pub user_id: String,
+}
+
 /// Repository trait for organization storage operations
 /// Infrastructure layer (e.g., ponix-postgres) implements this trait
 #[cfg_attr(any(test, feature = "testing"), mockall::automock)]
@@ -81,5 +87,11 @@ pub trait OrganizationRepository: Send + Sync {
     async fn list_organizations(
         &self,
         input: ListOrganizationsInput,
+    ) -> DomainResult<Vec<Organization>>;
+
+    /// Get organizations that a user belongs to (excludes soft deleted)
+    async fn get_organizations_by_user_id(
+        &self,
+        input: GetUserOrganizationsInput,
     ) -> DomainResult<Vec<Organization>>;
 }

--- a/crates/common/src/domain/result.rs
+++ b/crates/common/src/domain/result.rs
@@ -88,6 +88,9 @@ pub enum DomainError {
     #[error("User organization link already exists: user {0} in org {1}")]
     UserOrganizationAlreadyExists(String, String),
 
+    #[error("Permission denied: {0}")]
+    PermissionDenied(String),
+
     #[error("Repository error: {0}")]
     RepositoryError(#[from] anyhow::Error),
 }

--- a/crates/common/src/grpc/error.rs
+++ b/crates/common/src/grpc/error.rs
@@ -56,6 +56,8 @@ pub fn domain_error_to_status(error: DomainError) -> Status {
             Status::already_exists(format!("User {} already in organization {}", user_id, org_id))
         }
 
+        DomainError::PermissionDenied(msg) => Status::permission_denied(msg),
+
         DomainError::RepositoryError(err) => Status::internal(format!("Internal error: {}", err)),
     }
 }

--- a/crates/common/src/proto/organization.rs
+++ b/crates/common/src/proto/organization.rs
@@ -1,11 +1,11 @@
 use crate::domain::{
     CreateOrganizationInput, DeleteOrganizationInput, GetOrganizationInput,
-    ListOrganizationsInput, Organization,
+    GetUserOrganizationsInput, ListOrganizationsInput, Organization,
 };
 use chrono::{DateTime, Utc};
 use ponix_proto_prost::organization::v1::{
     CreateOrganizationRequest, DeleteOrganizationRequest, GetOrganizationRequest,
-    ListOrganizationsRequest, Organization as ProtoOrganization,
+    ListOrganizationsRequest, Organization as ProtoOrganization, UserOrganizationsRequest,
 };
 use prost_types::Timestamp;
 
@@ -59,6 +59,15 @@ pub fn to_delete_organization_input(req: DeleteOrganizationRequest) -> DeleteOrg
 /// Convert protobuf ListOrganizationsRequest to domain ListOrganizationsInput
 pub fn to_list_organizations_input(_req: ListOrganizationsRequest) -> ListOrganizationsInput {
     ListOrganizationsInput {}
+}
+
+/// Convert protobuf UserOrganizationsRequest to domain GetUserOrganizationsInput
+pub fn to_get_user_organizations_input(
+    req: UserOrganizationsRequest,
+) -> GetUserOrganizationsInput {
+    GetUserOrganizationsInput {
+        user_id: req.user_id,
+    }
 }
 
 #[cfg(test)]
@@ -118,5 +127,15 @@ mod tests {
 
         let input = to_delete_organization_input(req);
         assert_eq!(input.organization_id, "org-999");
+    }
+
+    #[test]
+    fn test_user_organizations_request_to_domain() {
+        let req = UserOrganizationsRequest {
+            user_id: "user-123".to_string(),
+        };
+
+        let input = to_get_user_organizations_input(req);
+        assert_eq!(input.user_id, "user-123");
     }
 }


### PR DESCRIPTION
## Summary

Implements GitHub issue #84 - adds a new `UserOrganizations` gRPC endpoint that allows authenticated users to retrieve the organizations they belong to.

### Changes

- **Domain Layer** (`crates/common/src/domain/organization.rs`):
  - Added `GetUserOrganizationsInput` struct
  - Extended `OrganizationRepository` trait with `get_organizations_by_user_id` method

- **Error Handling** (`crates/common/src/domain/result.rs`, `crates/common/src/grpc/error.rs`):
  - Added `PermissionDenied(String)` error variant
  - Added gRPC Status mapping for `PERMISSION_DENIED`

- **Repository** (`crates/common/src/postgres/organization_repository.rs`):
  - Implemented `get_organizations_by_user_id` with JOIN query on `user_organizations` table
  - Filters out soft-deleted organizations (`deleted_at IS NULL`)

- **Domain Service** (`crates/ponix_api/src/domain/organization_service.rs`):
  - Added `get_user_organizations` method with input validation
  - Added unit tests for empty user_id and success cases

- **Proto Conversion** (`crates/common/src/proto/organization.rs`):
  - Added `to_get_user_organizations_input` conversion function
  - Added unit test for the conversion

- **gRPC Handler** (`crates/ponix_api/src/grpc/organization_handler.rs`):
  - Implemented `user_organizations` endpoint
  - Authorization check: validates JWT `sub` claim matches requested `user_id`
  - Returns `PERMISSION_DENIED` if user tries to access another user's organizations

- **Integration Tests** (`crates/common/tests/organization_repository_integration.rs`):
  - Added 4 new integration tests:
    - `test_get_organizations_by_user_id` - User with multiple orgs gets all back
    - `test_get_organizations_by_user_id_empty` - User with no orgs gets empty list
    - `test_get_organizations_by_user_id_excludes_soft_deleted` - Soft-deleted orgs excluded
    - `test_get_organizations_by_user_id_multiple_users` - Users only see their own orgs

## Test plan

- [x] All unit tests pass: `mise run test:unit` (251 tests)
- [x] All integration tests pass: `cargo test -p common --features integration-tests --test organization_repository_integration` (14 tests)
- [x] Full workspace builds successfully

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)