### PR TITLE
feat: Add organization_id validation to entity access operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1131,7 +1131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1797,7 +1797,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -2873,9 +2873,9 @@ dependencies = [
 
 [[package]]
 name = "ponix_ponix_community_neoeinstein-prost"
-version = "0.5.0-20251207171615-b5863031b4f0.2"
+version = "0.5.0-20251208040237-c375efd56625.2"
 source = "sparse+https://buf.build/gen/cargo/"
-checksum = "629f3dd9f8ad0985748280c40af448d3680d67e02d988c0ebe99d6c91d734476"
+checksum = "fcc701e09784319bf879fa692404a907a3f5b94904c0926fad99db02bba3937c"
 dependencies = [
  "prost 0.14.1",
  "prost-types",
@@ -2883,9 +2883,9 @@ dependencies = [
 
 [[package]]
 name = "ponix_ponix_community_neoeinstein-tonic"
-version = "0.5.0-20251207171615-b5863031b4f0.4"
+version = "0.5.0-20251208040237-c375efd56625.4"
 source = "sparse+https://buf.build/gen/cargo/"
-checksum = "f4707b7843198ce374bd2a405d1e8c4ca383a221046c5ee7b71dfe6758b800fd"
+checksum = "cc5dfdc75460717bde1ac4b3ef77d7b458a003491a8f2efe159e0605dac297c3"
 dependencies = [
  "ponix_ponix_community_neoeinstein-prost",
  "tonic 0.14.2",
@@ -3124,7 +3124,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.35",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -3161,9 +3161,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3465,7 +3465,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/analytics_worker/src/domain/raw_envelope_service.rs
+++ b/crates/analytics_worker/src/domain/raw_envelope_service.rs
@@ -52,6 +52,7 @@ impl RawEnvelopeService {
             .device_repository
             .get_device(GetDeviceInput {
                 device_id: raw.end_device_id.clone(),
+                organization_id: raw.organization_id.clone(),
             })
             .await?
             .ok_or_else(|| DomainError::DeviceNotFound(raw.end_device_id.clone()))?;
@@ -200,7 +201,9 @@ mod tests {
 
         mock_device_repo
             .expect_get_device()
-            .withf(|input: &GetDeviceInput| input.device_id == "device-123")
+            .withf(|input: &GetDeviceInput| {
+                input.device_id == "device-123" && input.organization_id == "org-456"
+            })
             .times(1)
             .return_once(move |_| Ok(Some(device)));
 

--- a/crates/cdc_worker/src/domain/gateway_converter.rs
+++ b/crates/cdc_worker/src/domain/gateway_converter.rs
@@ -56,8 +56,10 @@ impl GatewayConverter {
             .to_string();
 
         // Extract broker_url and subscription_group from config and create Config oneof
-        let config = gateway_config.get("broker_url").and_then(|v| v.as_str()).map(
-            |broker_url| {
+        let config = gateway_config
+            .get("broker_url")
+            .and_then(|v| v.as_str())
+            .map(|broker_url| {
                 let subscription_group = gateway_config
                     .get("subscription_group")
                     .and_then(|v| v.as_str())
@@ -68,8 +70,7 @@ impl GatewayConverter {
                     broker_url: broker_url.to_string(),
                     subscription_group,
                 })
-            },
-        );
+            });
 
         // Default status to ACTIVE
         let status = GatewayStatus::Active as i32;

--- a/crates/cdc_worker/tests/gateway_cdc_integration.rs
+++ b/crates/cdc_worker/tests/gateway_cdc_integration.rs
@@ -3,9 +3,9 @@
 use async_nats::jetstream;
 use cdc_worker::domain::{CdcConfig, CdcProcess, EntityConfig, GatewayConverter};
 use common::domain::{
-    CreateGatewayInputWithId, CreateOrganizationInputWithId, EmqxGatewayConfig, GatewayConfig,
-    GatewayRepository, OrganizationRepository, RegisterUserInputWithId, UpdateGatewayInput,
-    UserRepository,
+    CreateGatewayInputWithId, CreateOrganizationInputWithId, DeleteGatewayInput, EmqxGatewayConfig,
+    GatewayConfig, GatewayRepository, OrganizationRepository, RegisterUserInputWithId,
+    UpdateGatewayInput, UserRepository,
 };
 use common::nats::NatsClient;
 use common::postgres::{
@@ -371,6 +371,7 @@ async fn test_gateway_update_cdc_event() {
     // Update the gateway
     let update_input = UpdateGatewayInput {
         gateway_id: gateway_id.clone(),
+        organization_id: "test-org-002".to_string(),
         gateway_type: None,
         gateway_config: Some(GatewayConfig::Emqx(EmqxGatewayConfig {
             broker_url: "mqtt://updated.example.com:8883".to_string(),
@@ -445,8 +446,12 @@ async fn test_gateway_delete_cdc_event() {
     info!("Initial gateway created and create event consumed");
 
     // Delete the gateway (soft delete)
+    let delete_input = DeleteGatewayInput {
+        gateway_id: gateway_id.clone(),
+        organization_id: "test-org-003".to_string(),
+    };
     env.gateway_repo
-        .delete_gateway(&gateway_id)
+        .delete_gateway(delete_input)
         .await
         .expect("Failed to delete gateway");
 

--- a/crates/common/src/auth/jwt.rs
+++ b/crates/common/src/auth/jwt.rs
@@ -6,10 +6,10 @@ use serde::{Deserialize, Serialize};
 /// JWT claims structure
 #[derive(Debug, Serialize, Deserialize)]
 pub struct JwtClaims {
-    pub sub: String,  // user_id
+    pub sub: String, // user_id
     pub email: String,
-    pub exp: usize,   // expiration timestamp
-    pub iat: usize,   // issued at timestamp
+    pub exp: usize, // expiration timestamp
+    pub iat: usize, // issued at timestamp
 }
 
 /// JWT-based implementation of AuthTokenProvider
@@ -60,13 +60,9 @@ impl AuthTokenProvider for JwtAuthTokenProvider {
         validation.insecure_disable_signature_validation();
         validation.validate_exp = false;
 
-        decode::<JwtClaims>(
-            token,
-            &DecodingKey::from_secret(&[]),
-            &validation,
-        )
-        .ok()
-        .map(|data| data.claims.sub)
+        decode::<JwtClaims>(token, &DecodingKey::from_secret(&[]), &validation)
+            .ok()
+            .map(|data| data.claims.sub)
     }
 }
 
@@ -89,7 +85,9 @@ mod tests {
     #[test]
     fn test_validate_token_success() {
         let provider = JwtAuthTokenProvider::new(test_config());
-        let token = provider.generate_token("user-123", "test@example.com").unwrap();
+        let token = provider
+            .generate_token("user-123", "test@example.com")
+            .unwrap();
 
         let user_id = provider.validate_token(&token);
         assert!(user_id.is_ok());
@@ -106,9 +104,12 @@ mod tests {
     #[test]
     fn test_validate_token_wrong_secret() {
         let provider1 = JwtAuthTokenProvider::new(test_config());
-        let provider2 = JwtAuthTokenProvider::new(JwtConfig::new("different-secret".to_string(), 24));
+        let provider2 =
+            JwtAuthTokenProvider::new(JwtConfig::new("different-secret".to_string(), 24));
 
-        let token = provider1.generate_token("user-123", "test@example.com").unwrap();
+        let token = provider1
+            .generate_token("user-123", "test@example.com")
+            .unwrap();
         let result = provider2.validate_token(&token);
         assert!(matches!(result, Err(DomainError::InvalidToken(_))));
     }
@@ -116,7 +117,9 @@ mod tests {
     #[test]
     fn test_extract_user_id_success() {
         let provider = JwtAuthTokenProvider::new(test_config());
-        let token = provider.generate_token("user-123", "test@example.com").unwrap();
+        let token = provider
+            .generate_token("user-123", "test@example.com")
+            .unwrap();
 
         let user_id = provider.extract_user_id(&token);
         assert_eq!(user_id, Some("user-123".to_string()));

--- a/crates/common/src/domain/end_device.rs
+++ b/crates/common/src/domain/end_device.rs
@@ -37,6 +37,7 @@ pub struct CreateDeviceInputWithId {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetDeviceInput {
     pub device_id: String,
+    pub organization_id: String,
 }
 
 /// Input for listing devices by organization

--- a/crates/common/src/domain/gateway.rs
+++ b/crates/common/src/domain/gateway.rs
@@ -35,12 +35,14 @@ pub struct CreateGatewayInputWithId {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetGatewayInput {
     pub gateway_id: String,
+    pub organization_id: String,
 }
 
 /// Input for updating a gateway
 #[derive(Debug, Clone, PartialEq)]
 pub struct UpdateGatewayInput {
     pub gateway_id: String,
+    pub organization_id: String,
     pub gateway_type: Option<String>,
     pub gateway_config: Option<GatewayConfig>,
 }
@@ -49,6 +51,7 @@ pub struct UpdateGatewayInput {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeleteGatewayInput {
     pub gateway_id: String,
+    pub organization_id: String,
 }
 
 /// Input for listing gateways by organization
@@ -82,14 +85,14 @@ pub trait GatewayRepository: Send + Sync {
     /// Create a new gateway
     async fn create_gateway(&self, input: CreateGatewayInputWithId) -> DomainResult<Gateway>;
 
-    /// Get a gateway by ID (excludes soft deleted)
-    async fn get_gateway(&self, gateway_id: &str) -> DomainResult<Option<Gateway>>;
+    /// Get a gateway by ID and organization (excludes soft deleted)
+    async fn get_gateway(&self, input: GetGatewayInput) -> DomainResult<Option<Gateway>>;
 
     /// Update a gateway
     async fn update_gateway(&self, input: UpdateGatewayInput) -> DomainResult<Gateway>;
 
     /// Soft delete a gateway
-    async fn delete_gateway(&self, gateway_id: &str) -> DomainResult<()>;
+    async fn delete_gateway(&self, input: DeleteGatewayInput) -> DomainResult<()>;
 
     /// List gateways by organization (excludes soft deleted)
     async fn list_gateways(&self, organization_id: &str) -> DomainResult<Vec<Gateway>>;

--- a/crates/common/src/grpc/error.rs
+++ b/crates/common/src/grpc/error.rs
@@ -46,15 +46,17 @@ pub fn domain_error_to_status(error: DomainError) -> Status {
 
         DomainError::InvalidCredentials => Status::unauthenticated("Invalid email or password"),
 
-        DomainError::InvalidToken(msg) => Status::unauthenticated(format!("Invalid token: {}", msg)),
+        DomainError::InvalidToken(msg) => {
+            Status::unauthenticated(format!("Invalid token: {}", msg))
+        }
 
         DomainError::RefreshTokenNotFound => Status::unauthenticated("Refresh token not found"),
 
         DomainError::RefreshTokenExpired => Status::unauthenticated("Refresh token expired"),
 
-        DomainError::UserOrganizationAlreadyExists(user_id, org_id) => {
-            Status::already_exists(format!("User {} already in organization {}", user_id, org_id))
-        }
+        DomainError::UserOrganizationAlreadyExists(user_id, org_id) => Status::already_exists(
+            format!("User {} already in organization {}", user_id, org_id),
+        ),
 
         DomainError::PermissionDenied(msg) => Status::permission_denied(msg),
 

--- a/crates/common/src/postgres/device_repository.rs
+++ b/crates/common/src/postgres/device_repository.rs
@@ -97,7 +97,7 @@ impl DeviceRepository for PostgresDeviceRepository {
         })
     }
 
-    #[instrument(skip(self, input), fields(device_id = %input.device_id))]
+    #[instrument(skip(self, input), fields(device_id = %input.device_id, organization_id = %input.organization_id))]
     async fn get_device(&self, input: GetDeviceInput) -> DomainResult<Option<Device>> {
         let conn = self
             .client
@@ -109,8 +109,8 @@ impl DeviceRepository for PostgresDeviceRepository {
             .query_opt(
                 "SELECT device_id, organization_id, device_name, payload_conversion, created_at, updated_at
                  FROM devices
-                 WHERE device_id = $1",
-                &[&input.device_id],
+                 WHERE device_id = $1 AND organization_id = $2",
+                &[&input.device_id, &input.organization_id],
             )
             .await
             .map_err(|e| DomainError::RepositoryError(e.into()))?;

--- a/crates/common/src/proto/device.rs
+++ b/crates/common/src/proto/device.rs
@@ -45,6 +45,7 @@ pub fn to_proto_device(device: Device) -> EndDevice {
 pub fn to_get_device_input(req: GetEndDeviceRequest) -> GetDeviceInput {
     GetDeviceInput {
         device_id: req.device_id,
+        organization_id: req.organization_id,
     }
 }
 

--- a/crates/common/src/proto/gateway.rs
+++ b/crates/common/src/proto/gateway.rs
@@ -112,6 +112,7 @@ fn string_to_gateway_type(s: &str) -> GatewayType {
 pub fn to_get_gateway_input(request: GetGatewayRequest) -> GetGatewayInput {
     GetGatewayInput {
         gateway_id: request.gateway_id,
+        organization_id: request.organization_id,
     }
 }
 
@@ -143,6 +144,7 @@ pub fn to_update_gateway_input(request: UpdateGatewayRequest) -> UpdateGatewayIn
 
     UpdateGatewayInput {
         gateway_id: request.gateway_id,
+        organization_id: request.organization_id,
         gateway_type,
         gateway_config,
     }
@@ -152,6 +154,7 @@ pub fn to_update_gateway_input(request: UpdateGatewayRequest) -> UpdateGatewayIn
 pub fn to_delete_gateway_input(request: DeleteGatewayRequest) -> DeleteGatewayInput {
     DeleteGatewayInput {
         gateway_id: request.gateway_id,
+        organization_id: request.organization_id,
     }
 }
 

--- a/crates/common/src/proto/organization.rs
+++ b/crates/common/src/proto/organization.rs
@@ -62,9 +62,7 @@ pub fn to_list_organizations_input(_req: ListOrganizationsRequest) -> ListOrgani
 }
 
 /// Convert protobuf UserOrganizationsRequest to domain GetUserOrganizationsInput
-pub fn to_get_user_organizations_input(
-    req: UserOrganizationsRequest,
-) -> GetUserOrganizationsInput {
+pub fn to_get_user_organizations_input(req: UserOrganizationsRequest) -> GetUserOrganizationsInput {
     GetUserOrganizationsInput {
         user_id: req.user_id,
     }

--- a/crates/gateway_orchestrator/src/gateway_orchestrator.rs
+++ b/crates/gateway_orchestrator/src/gateway_orchestrator.rs
@@ -32,11 +32,9 @@ impl GatewayOrchestrator {
 
         // Create raw envelope producer for gateway processes
         let publisher_client = nats_client.create_publisher_client();
-        let raw_envelope_producer: Arc<dyn common::domain::RawEnvelopeProducer> =
-            Arc::new(RawEnvelopeProducer::new(
-                publisher_client,
-                config.raw_envelopes_stream.clone(),
-            ));
+        let raw_envelope_producer: Arc<dyn common::domain::RawEnvelopeProducer> = Arc::new(
+            RawEnvelopeProducer::new(publisher_client, config.raw_envelopes_stream.clone()),
+        );
 
         // Configure gateway runner factory with supported gateway types
         let mut runner_factory = GatewayRunnerFactory::new();

--- a/crates/gateway_orchestrator/src/mqtt/subscriber.rs
+++ b/crates/gateway_orchestrator/src/mqtt/subscriber.rs
@@ -1,6 +1,8 @@
 use crate::domain::GatewayOrchestrationServiceConfig;
 use crate::mqtt::parse_topic;
-use common::domain::{DomainError, DomainResult, Gateway, GatewayConfig, RawEnvelope, RawEnvelopeProducer};
+use common::domain::{
+    DomainError, DomainResult, Gateway, GatewayConfig, RawEnvelope, RawEnvelopeProducer,
+};
 use rumqttc::v5::mqttbytes::QoS;
 use rumqttc::v5::{AsyncClient, Event, MqttOptions};
 use std::sync::Arc;
@@ -137,9 +139,7 @@ async fn run_mqtt_connection(
     client
         .subscribe(&subscribe_topic, QoS::AtLeastOnce)
         .await
-        .map_err(|e| {
-            DomainError::RepositoryError(anyhow::anyhow!("Failed to subscribe: {}", e))
-        })?;
+        .map_err(|e| DomainError::RepositoryError(anyhow::anyhow!("Failed to subscribe: {}", e)))?;
 
     info!(
         gateway_id = %gateway.gateway_id,
@@ -286,7 +286,10 @@ fn parse_broker_url(url: &str) -> DomainResult<(&str, u16)> {
         1 => Ok((parts[0], 1883)), // Default MQTT port
         2 => {
             let port = parts[1].parse::<u16>().map_err(|_| {
-                DomainError::InvalidGatewayConfig(format!("Invalid port in broker URL: {}", parts[1]))
+                DomainError::InvalidGatewayConfig(format!(
+                    "Invalid port in broker URL: {}",
+                    parts[1]
+                ))
             })?;
             Ok((parts[0], port))
         }
@@ -362,7 +365,13 @@ mod tests {
 
         let producer: Arc<dyn RawEnvelopeProducer> = Arc::new(mock_producer);
 
-        handle_mqtt_message(&gateway, "org-001/device-123", &[0x01, 0x02, 0x03], producer).await;
+        handle_mqtt_message(
+            &gateway,
+            "org-001/device-123",
+            &[0x01, 0x02, 0x03],
+            producer,
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -394,6 +403,12 @@ mod tests {
 
         let producer: Arc<dyn RawEnvelopeProducer> = Arc::new(mock_producer);
 
-        handle_mqtt_message(&gateway, "invalid-topic-format", &[0x01, 0x02, 0x03], producer).await;
+        handle_mqtt_message(
+            &gateway,
+            "invalid-topic-format",
+            &[0x01, 0x02, 0x03],
+            producer,
+        )
+        .await;
     }
 }

--- a/crates/gateway_orchestrator/src/nats/gateway_cdc_consumer.rs
+++ b/crates/gateway_orchestrator/src/nats/gateway_cdc_consumer.rs
@@ -53,8 +53,8 @@ impl GatewayCdcConsumer {
             &stream_name,
             &consumer_name,
             &filter_subject,
-            10,  // batch size
-            5,   // max wait seconds
+            10, // batch size
+            5,  // max wait seconds
             layered_service,
         )
         .await?;

--- a/crates/gateway_orchestrator/src/nats/gateway_cdc_service.rs
+++ b/crates/gateway_orchestrator/src/nats/gateway_cdc_service.rs
@@ -49,10 +49,7 @@ impl Service<ConsumeRequest> for GatewayCdcService {
                         error = %e,
                         "failed to parse gateway CDC event"
                     );
-                    return Ok(ConsumeResponse::Nak(Some(format!(
-                        "parse error: {}",
-                        e
-                    ))));
+                    return Ok(ConsumeResponse::Nak(Some(format!("parse error: {}", e))));
                 }
             };
 

--- a/crates/gateway_orchestrator/tests/gateway_orchestrator_test.rs
+++ b/crates/gateway_orchestrator/tests/gateway_orchestrator_test.rs
@@ -2,8 +2,9 @@
 
 use async_trait::async_trait;
 use common::domain::{
-    CreateGatewayInputWithId, DomainError, DomainResult, EmqxGatewayConfig, Gateway, GatewayConfig,
-    GatewayRepository, MockRawEnvelopeProducer, RawEnvelopeProducer, UpdateGatewayInput,
+    CreateGatewayInputWithId, DeleteGatewayInput, DomainError, DomainResult, EmqxGatewayConfig,
+    Gateway, GatewayConfig, GatewayRepository, GetGatewayInput, MockRawEnvelopeProducer,
+    RawEnvelopeProducer, UpdateGatewayInput,
 };
 use gateway_orchestrator::domain::{
     GatewayOrchestrationService, GatewayOrchestrationServiceConfig, GatewayProcessStore,
@@ -81,9 +82,9 @@ mod mocks {
             unimplemented!("Not needed for orchestrator tests")
         }
 
-        async fn get_gateway(&self, gateway_id: &str) -> DomainResult<Option<Gateway>> {
+        async fn get_gateway(&self, input: GetGatewayInput) -> DomainResult<Option<Gateway>> {
             let gateways = self.gateways.lock().unwrap();
-            Ok(gateways.get(gateway_id).cloned())
+            Ok(gateways.get(&input.gateway_id).cloned())
         }
 
         async fn list_gateways(&self, _organization_id: &str) -> DomainResult<Vec<Gateway>> {
@@ -111,13 +112,13 @@ mod mocks {
             }
         }
 
-        async fn delete_gateway(&self, gateway_id: &str) -> DomainResult<()> {
+        async fn delete_gateway(&self, input: DeleteGatewayInput) -> DomainResult<()> {
             let mut gateways = self.gateways.lock().unwrap();
-            if let Some(gateway) = gateways.get_mut(gateway_id) {
+            if let Some(gateway) = gateways.get_mut(&input.gateway_id) {
                 gateway.deleted_at = Some(chrono::Utc::now());
                 Ok(())
             } else {
-                Err(DomainError::GatewayNotFound(gateway_id.to_string()))
+                Err(DomainError::GatewayNotFound(input.gateway_id))
             }
         }
     }

--- a/crates/ponix_all_in_one/src/main.rs
+++ b/crates/ponix_all_in_one/src/main.rs
@@ -3,6 +3,9 @@ mod config;
 use analytics_worker::analytics_worker::{AnalyticsWorker, AnalyticsWorkerConfig};
 use cdc_worker::cdc_worker::{CdcWorker, CdcWorkerConfig};
 use cdc_worker::domain::{CdcConfig, EntityConfig, GatewayConverter};
+use common::auth::{
+    Argon2PasswordService, CryptoRefreshTokenProvider, JwtAuthTokenProvider, JwtConfig,
+};
 use common::clickhouse::ClickHouseClient;
 use common::grpc::{CorsConfig, GrpcLoggingConfig, GrpcServerConfig, GrpcTracingConfig};
 use common::nats::NatsClient;
@@ -14,7 +17,6 @@ use common::telemetry::{init_telemetry, shutdown_telemetry, TelemetryConfig, Tel
 use config::ServiceConfig;
 use gateway_orchestrator::gateway_orchestrator::{GatewayOrchestrator, GatewayOrchestratorConfig};
 use goose::MigrationRunner;
-use common::auth::{Argon2PasswordService, CryptoRefreshTokenProvider, JwtAuthTokenProvider, JwtConfig};
 use ponix_api::domain::{DeviceService, GatewayService, OrganizationService, UserService};
 use ponix_api::ponix_api::PonixApi;
 use ponix_runner::Runner;
@@ -76,10 +78,7 @@ async fn main() {
         postgres_repos.gateway.clone(),
         postgres_repos.organization.clone(),
     ));
-    let jwt_config = JwtConfig::new(
-        config.jwt_secret.clone(),
-        config.jwt_expiration_hours,
-    );
+    let jwt_config = JwtConfig::new(config.jwt_secret.clone(), config.jwt_expiration_hours);
     let auth_token_provider: Arc<dyn common::auth::AuthTokenProvider> =
         Arc::new(JwtAuthTokenProvider::new(jwt_config));
     let password_service: Arc<dyn common::auth::PasswordService> =

--- a/crates/ponix_all_in_one/tests/e2e_pipeline_test.rs
+++ b/crates/ponix_all_in_one/tests/e2e_pipeline_test.rs
@@ -262,12 +262,7 @@ async fn initialize_services(
         processed_producer,
     ));
 
-    Ok((
-        device_service,
-        raw_envelope_service,
-        nats_client,
-        pg_client,
-    ))
+    Ok((device_service, raw_envelope_service, nats_client, pg_client))
 }
 
 /// Create a test organization and device with CEL expression for Cayenne LPP transformation
@@ -368,9 +363,9 @@ async fn run_consumers(
     // Create raw envelope consumer with Tower middleware
     let raw_service = RawEnvelopeConsumerService::new(raw_envelope_service);
     let raw_service_stack = ServiceBuilder::new()
-        .layer(NatsConsumeTracingLayer::new(
-            NatsConsumeTracingConfig::new("raw_envelope_consume"),
-        ))
+        .layer(NatsConsumeTracingLayer::new(NatsConsumeTracingConfig::new(
+            "raw_envelope_consume",
+        )))
         .layer(NatsConsumeLoggingLayer::new())
         .service(raw_service);
 
@@ -389,9 +384,9 @@ async fn run_consumers(
     // Create processed envelope consumer with Tower middleware
     let processed_service = ProcessedEnvelopeConsumerService::new(inserter_repo.clone());
     let processed_service_stack = ServiceBuilder::new()
-        .layer(NatsConsumeTracingLayer::new(
-            NatsConsumeTracingConfig::new("processed_envelope_consume"),
-        ))
+        .layer(NatsConsumeTracingLayer::new(NatsConsumeTracingConfig::new(
+            "processed_envelope_consume",
+        )))
         .layer(NatsConsumeLoggingLayer::new())
         .service(processed_service);
 

--- a/crates/ponix_api/src/domain/organization_service.rs
+++ b/crates/ponix_api/src/domain/organization_service.rs
@@ -174,9 +174,7 @@ mod tests {
         mock_repo
             .expect_create_organization()
             .withf(|input: &CreateOrganizationInputWithId| {
-                !input.id.is_empty()
-                    && input.name == "Test Org"
-                    && input.user_id == "user-123"
+                !input.id.is_empty() && input.name == "Test Org" && input.user_id == "user-123"
             })
             .times(1)
             .return_once(move |_| Ok(expected_org.clone()));

--- a/crates/ponix_api/src/domain/user_service.rs
+++ b/crates/ponix_api/src/domain/user_service.rs
@@ -178,7 +178,10 @@ impl UserService {
 
     /// Refresh access token using a valid refresh token
     #[instrument(skip(self, input))]
-    pub async fn refresh_token(&self, input: RefreshTokenInput) -> DomainResult<RefreshTokenOutput> {
+    pub async fn refresh_token(
+        &self,
+        input: RefreshTokenInput,
+    ) -> DomainResult<RefreshTokenOutput> {
         debug!("attempting token refresh");
 
         // Hash the incoming token to look up in database

--- a/crates/ponix_api/src/grpc/device_handler.rs
+++ b/crates/ponix_api/src/grpc/device_handler.rs
@@ -65,7 +65,10 @@ impl DeviceServiceTrait for DeviceServiceHandler {
     #[instrument(
         name = "GetEndDevice",
         skip(self, request),
-        fields(device_id = %request.get_ref().device_id)
+        fields(
+            device_id = %request.get_ref().device_id,
+            organization_id = %request.get_ref().organization_id
+        )
     )]
     async fn get_end_device(
         &self,

--- a/crates/ponix_api/src/grpc/gateway_handler.rs
+++ b/crates/ponix_api/src/grpc/gateway_handler.rs
@@ -62,7 +62,10 @@ impl GatewayServiceTrait for GatewayServiceHandler {
     #[instrument(
         name = "GetGateway",
         skip(self, request),
-        fields(gateway_id = %request.get_ref().gateway_id)
+        fields(
+            gateway_id = %request.get_ref().gateway_id,
+            organization_id = %request.get_ref().organization_id
+        )
     )]
     async fn get_gateway(
         &self,
@@ -114,7 +117,10 @@ impl GatewayServiceTrait for GatewayServiceHandler {
     #[instrument(
         name = "UpdateGateway",
         skip(self, request),
-        fields(gateway_id = %request.get_ref().gateway_id)
+        fields(
+            gateway_id = %request.get_ref().gateway_id,
+            organization_id = %request.get_ref().organization_id
+        )
     )]
     async fn update_gateway(
         &self,
@@ -140,7 +146,10 @@ impl GatewayServiceTrait for GatewayServiceHandler {
     #[instrument(
         name = "DeleteGateway",
         skip(self, request),
-        fields(gateway_id = %request.get_ref().gateway_id)
+        fields(
+            gateway_id = %request.get_ref().gateway_id,
+            organization_id = %request.get_ref().organization_id
+        )
     )]
     async fn delete_gateway(
         &self,

--- a/crates/ponix_api/src/grpc/organization_handler.rs
+++ b/crates/ponix_api/src/grpc/organization_handler.rs
@@ -4,13 +4,13 @@ use tracing::{debug, instrument};
 
 use crate::domain::OrganizationService;
 use common::auth::AuthTokenProvider;
+use common::domain::DomainError;
 use common::grpc::domain_error_to_status;
 use common::proto::{
     datetime_to_timestamp, to_create_organization_input, to_delete_organization_input,
     to_get_organization_input, to_get_user_organizations_input, to_list_organizations_input,
     to_proto_organization,
 };
-use common::domain::DomainError;
 use ponix_proto_prost::organization::v1::{
     CreateOrganizationRequest, CreateOrganizationResponse, DeleteOrganizationRequest,
     DeleteOrganizationResponse, GetOrganizationRequest, GetOrganizationResponse,
@@ -183,7 +183,10 @@ impl OrganizationServiceTrait for OrganizationServiceHandler {
             .map(to_proto_organization)
             .collect();
 
-        debug!(count = proto_organizations.len(), "Organizations listed successfully");
+        debug!(
+            count = proto_organizations.len(),
+            "Organizations listed successfully"
+        );
 
         Ok(Response::new(ListOrganizationsResponse {
             organizations: proto_organizations,
@@ -227,7 +230,10 @@ impl OrganizationServiceTrait for OrganizationServiceHandler {
             .map(to_proto_organization)
             .collect();
 
-        debug!(count = proto_organizations.len(), "User organizations retrieved successfully");
+        debug!(
+            count = proto_organizations.len(),
+            "User organizations retrieved successfully"
+        );
 
         Ok(Response::new(UserOrganizationsResponse {
             organizations: proto_organizations,

--- a/crates/ponix_api/src/grpc/user_handler.rs
+++ b/crates/ponix_api/src/grpc/user_handler.rs
@@ -4,8 +4,12 @@ use tracing::{debug, info, instrument};
 
 use crate::domain::UserService;
 use common::auth::{LogoutInput, RefreshTokenInput};
-use common::grpc::{domain_error_to_status, extract_refresh_token_from_cookies, RefreshTokenCookie};
-use common::proto::{to_get_user_input, to_login_user_input, to_proto_user, to_register_user_input};
+use common::grpc::{
+    domain_error_to_status, extract_refresh_token_from_cookies, RefreshTokenCookie,
+};
+use common::proto::{
+    to_get_user_input, to_login_user_input, to_proto_user, to_register_user_input,
+};
 use ponix_proto_prost::user::v1::{
     GetUserRequest, GetUserResponse, LoginRequest, LoginResponse, LogoutRequest, LogoutResponse,
     RefreshRequest, RefreshResponse, RegisterUserRequest, RegisterUserResponse,
@@ -151,8 +155,8 @@ impl UserServiceTrait for UserServiceHandler {
             "Refresh endpoint - received cookie header"
         );
 
-        let refresh_token = extracted_token
-            .ok_or_else(|| Status::unauthenticated("Refresh token not found"))?;
+        let refresh_token =
+            extracted_token.ok_or_else(|| Status::unauthenticated("Refresh token not found"))?;
 
         let output = self
             .domain_service


### PR DESCRIPTION
## Summary

This PR implements organization-scoped access control for entity operations, ensuring that users can only access entities belonging to their organization. This addresses a critical multi-tenancy security requirement.

### Changes

**Domain Layer:**
- Added `organization_id` field to `GetDeviceInput`, `GetGatewayInput`, `UpdateGatewayInput`, and `DeleteGatewayInput`
- Updated `GatewayRepository` trait signatures for `get_gateway` and `delete_gateway` to accept full input structs

**Service Layer:**
- Added empty `organization_id` validation in service methods, returning `INVALID_ARGUMENT` error
- Repository queries now filter by `organization_id`, returning `NOT_FOUND` for cross-organization access attempts

**Repository Layer:**
- Updated SQL queries to include `organization_id` in WHERE clauses for:
  - `get_device` - filters by device_id AND organization_id
  - `get_gateway` - filters by gateway_id AND organization_id
  - `update_gateway` - filters by gateway_id AND organization_id
  - `delete_gateway` - filters by gateway_id AND organization_id

**gRPC Layer:**
- Updated handler instrumentation to log `organization_id` in traces

**Tests:**
- Updated existing integration tests to use new API signatures
- Added new cross-organization access tests:
  - `test_get_device_with_wrong_organization_returns_none`
  - `test_get_gateway_with_wrong_organization_returns_none`
  - `test_update_gateway_with_wrong_organization_returns_not_found`
  - `test_delete_gateway_with_wrong_organization_returns_not_found`

### Security Impact

This change prevents cross-organization data access by:
1. Requiring `organization_id` on all entity access requests
2. Validating that entities belong to the specified organization at the database level
3. Returning generic `NOT_FOUND` errors (not `FORBIDDEN`) to avoid information disclosure

## Test plan

- [x] Unit tests pass (40 ponix_api tests)
- [x] Integration tests pass with cross-organization access validation
- [x] Build passes
- [x] Clippy passes
- [x] Format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)