### PR TITLE
feat: add JSON Schema validation for processed envelopes

### DIFF
--- a/crates/analytics_worker/src/analytics_worker.rs
+++ b/crates/analytics_worker/src/analytics_worker.rs
@@ -1,5 +1,6 @@
 use crate::clickhouse::{ClickHouseInserterRepository, InserterCommitHandle, InserterConfig};
 use crate::domain::{CelPayloadConverter, RawEnvelopeService};
+use common::jsonschema::JsonSchemaValidator;
 use crate::nats::{
     ProcessedEnvelopeConsumerService, ProcessedEnvelopeProducer, RawEnvelopeConsumerService,
 };
@@ -114,11 +115,15 @@ impl AnalyticsWorker {
             config.processed_envelopes_stream.clone(),
         ));
 
+        // Initialize schema validator
+        let schema_validator = Arc::new(JsonSchemaValidator::new());
+
         let raw_envelope_domain_service = Arc::new(RawEnvelopeService::new(
             device_repository,
             organization_repository,
             payload_converter,
             processed_envelope_producer,
+            schema_validator,
         ));
 
         // Build RawEnvelope Tower service with middleware layers

--- a/crates/common/src/domain/end_device.rs
+++ b/crates/common/src/domain/end_device.rs
@@ -1,6 +1,7 @@
 use crate::domain::result::DomainResult;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use garde::Validate;
 
 /// Domain representation of a Device
 /// Simple String types for now - can evolve to newtypes later
@@ -16,16 +17,25 @@ pub struct Device {
 
 /// Device with its associated definition data (joined query result)
 /// Used when we need both device info and the backing definition
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Validate)]
 pub struct DeviceWithDefinition {
+    #[garde(skip)]
     pub device_id: String,
+    #[garde(skip)]
     pub organization_id: String,
+    #[garde(skip)]
     pub definition_id: String,
+    #[garde(skip)]
     pub definition_name: String,
+    #[garde(skip)]
     pub name: String,
+    #[garde(length(min = 1))]
     pub payload_conversion: String,
+    #[garde(length(min = 1))]
     pub json_schema: String,
+    #[garde(skip)]
     pub created_at: Option<DateTime<Utc>>,
+    #[garde(skip)]
     pub updated_at: Option<DateTime<Utc>>,
 }
 

--- a/crates/common/src/domain/result.rs
+++ b/crates/common/src/domain/result.rs
@@ -22,9 +22,6 @@ pub enum DomainError {
     #[error("Payload conversion error: {0}")]
     PayloadConversionError(String),
 
-    #[error("Missing CEL expression for device: {0}")]
-    MissingCelExpression(String),
-
     #[error("End device definition not found: {0}")]
     EndDeviceDefinitionNotFound(String),
 
@@ -33,6 +30,9 @@ pub enum DomainError {
 
     #[error("Invalid JSON Schema: {0}")]
     InvalidJsonSchema(String),
+
+    #[error("Schema validation failed for device {0}: {1}")]
+    SchemaValidationFailed(String, String),
 
     #[error("End device definition in use: {0}")]
     EndDeviceDefinitionInUse(String),

--- a/crates/common/src/garde/validate.rs
+++ b/crates/common/src/garde/validate.rs
@@ -4,7 +4,7 @@ use crate::domain::DomainError;
 use garde::{Report, Validate};
 
 /// Convert garde validation report to DomainError
-pub fn validate<T>(value: &T) -> Result<(), DomainError>
+pub fn validate_struct<T>(value: &T) -> Result<(), DomainError>
 where
     T: Validate,
     T::Context: Default,
@@ -45,7 +45,7 @@ mod tests {
         let request = TestRequest {
             field: "value".to_string(),
         };
-        assert!(validate(&request).is_ok());
+        assert!(validate_struct(&request).is_ok());
     }
 
     #[test]
@@ -53,7 +53,7 @@ mod tests {
         let request = TestRequest {
             field: "".to_string(),
         };
-        let result = validate(&request);
+        let result = validate_struct(&request);
         assert!(matches!(result, Err(DomainError::ValidationError(_))));
     }
 
@@ -62,7 +62,7 @@ mod tests {
         let request = TestRequest {
             field: "".to_string(),
         };
-        let result = validate(&request);
+        let result = validate_struct(&request);
         if let Err(DomainError::ValidationError(msg)) = result {
             // Garde generates a message like "field: length is lower than 1"
             assert!(msg.contains("field"));

--- a/crates/common/src/grpc/error.rs
+++ b/crates/common/src/grpc/error.rs
@@ -15,13 +15,16 @@ pub fn domain_error_to_status(error: DomainError) -> Status {
 
         DomainError::PayloadConversionError(msg) => Status::invalid_argument(msg),
 
-        DomainError::MissingCelExpression(msg) => Status::failed_precondition(msg),
-
         DomainError::EndDeviceDefinitionNotFound(msg) => Status::not_found(msg),
 
         DomainError::EndDeviceDefinitionAlreadyExists(msg) => Status::already_exists(msg),
 
         DomainError::InvalidJsonSchema(msg) => Status::invalid_argument(msg),
+
+        DomainError::SchemaValidationFailed(device_id, reason) => Status::invalid_argument(format!(
+            "Schema validation failed for device {}: {}",
+            device_id, reason
+        )),
 
         DomainError::EndDeviceDefinitionInUse(msg) => Status::failed_precondition(msg),
 

--- a/crates/common/src/jsonschema.rs
+++ b/crates/common/src/jsonschema.rs
@@ -1,5 +1,9 @@
 //! JSON Schema validation module.
 
+mod json_schema_validator;
+mod schema_validator;
 mod validate;
 
+pub use json_schema_validator::*;
+pub use schema_validator::*;
 pub use validate::*;

--- a/crates/common/src/jsonschema/json_schema_validator.rs
+++ b/crates/common/src/jsonschema/json_schema_validator.rs
@@ -1,0 +1,137 @@
+//! JSON Schema validator implementation.
+
+use crate::jsonschema::{SchemaValidationError, SchemaValidationResult, SchemaValidator};
+use jsonschema::Validator;
+
+/// JSON Schema validator implementation.
+///
+/// Uses the `jsonschema` crate for validation against JSON Schema Draft 2020-12.
+pub struct JsonSchemaValidator;
+
+// TODO: Add LRU cache keyed by schema hash for performance optimization
+// Consider using `lru` crate with schema string hash as key
+
+impl JsonSchemaValidator {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for JsonSchemaValidator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SchemaValidator for JsonSchemaValidator {
+    fn validate(&self, schema_str: &str, data: &serde_json::Value) -> SchemaValidationResult<()> {
+        // Parse the schema string as JSON
+        let schema_value: serde_json::Value =
+            serde_json::from_str(schema_str).map_err(|e| SchemaValidationError {
+                message: format!("Invalid schema JSON: {}", e),
+            })?;
+
+        // Compile the schema
+        let validator = Validator::new(&schema_value).map_err(|e| SchemaValidationError {
+            message: format!("Invalid JSON Schema: {}", e),
+        })?;
+
+        // Validate the data - collect all errors
+        let errors: Vec<String> = validator
+            .iter_errors(data)
+            .map(|e| format!("{} at {}", e, e.instance_path))
+            .collect();
+
+        if !errors.is_empty() {
+            return Err(SchemaValidationError {
+                message: errors.join("; "),
+            });
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_schema_allows_any_object() {
+        let validator = JsonSchemaValidator::new();
+        let schema = "{}";
+        let data = serde_json::json!({"temperature": 25.5, "humidity": 60});
+
+        assert!(validator.validate(schema, &data).is_ok());
+    }
+
+    #[test]
+    fn test_valid_data_passes_schema() {
+        let validator = JsonSchemaValidator::new();
+        let schema = r#"{
+            "type": "object",
+            "properties": {
+                "temperature": {"type": "number"},
+                "humidity": {"type": "number"}
+            },
+            "required": ["temperature"]
+        }"#;
+        let data = serde_json::json!({"temperature": 25.5, "humidity": 60});
+
+        assert!(validator.validate(schema, &data).is_ok());
+    }
+
+    #[test]
+    fn test_missing_required_field_fails() {
+        let validator = JsonSchemaValidator::new();
+        let schema = r#"{
+            "type": "object",
+            "properties": {
+                "temperature": {"type": "number"}
+            },
+            "required": ["temperature"]
+        }"#;
+        let data = serde_json::json!({"humidity": 60});
+
+        let result = validator.validate(schema, &data);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().message.contains("required"));
+    }
+
+    #[test]
+    fn test_wrong_type_fails() {
+        let validator = JsonSchemaValidator::new();
+        let schema = r#"{
+            "type": "object",
+            "properties": {
+                "temperature": {"type": "number"}
+            }
+        }"#;
+        let data = serde_json::json!({"temperature": "not a number"});
+
+        let result = validator.validate(schema, &data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_invalid_schema_json_fails() {
+        let validator = JsonSchemaValidator::new();
+        let schema = "not valid json";
+        let data = serde_json::json!({"temperature": 25.5});
+
+        let result = validator.validate(schema, &data);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().message.contains("Invalid schema JSON"));
+    }
+
+    #[test]
+    fn test_invalid_schema_type_fails() {
+        let validator = JsonSchemaValidator::new();
+        let schema = r#"{"type": "not_a_valid_type"}"#;
+        let data = serde_json::json!({"temperature": 25.5});
+
+        let result = validator.validate(schema, &data);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().message.contains("Invalid JSON Schema"));
+    }
+}

--- a/crates/common/src/jsonschema/schema_validator.rs
+++ b/crates/common/src/jsonschema/schema_validator.rs
@@ -1,0 +1,41 @@
+//! Schema validator trait for JSON Schema validation.
+
+/// Result type for schema validation operations.
+pub type SchemaValidationResult<T> = Result<T, SchemaValidationError>;
+
+/// Error type for schema validation failures.
+#[derive(Debug, Clone)]
+pub struct SchemaValidationError {
+    /// The validation error message(s)
+    pub message: String,
+}
+
+impl std::fmt::Display for SchemaValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for SchemaValidationError {}
+
+/// Validates JSON data against a JSON Schema.
+///
+/// The schema_str should be a valid JSON Schema (Draft 2020-12).
+/// Empty schema `{}` is permissive and allows any valid JSON.
+#[cfg_attr(any(test, feature = "testing"), mockall::automock)]
+pub trait SchemaValidator: Send + Sync {
+    /// Validate data against a JSON Schema.
+    ///
+    /// # Arguments
+    /// * `schema_str` - The JSON Schema as a string
+    /// * `data` - The JSON value to validate
+    ///
+    /// # Returns
+    /// * `Ok(())` if validation passes
+    /// * `Err(SchemaValidationError)` if validation fails
+    fn validate(
+        &self,
+        schema_str: &str,
+        data: &serde_json::Value,
+    ) -> SchemaValidationResult<()>;
+}

--- a/crates/ponix_all_in_one/tests/e2e_pipeline_test.rs
+++ b/crates/ponix_all_in_one/tests/e2e_pipeline_test.rs
@@ -17,6 +17,7 @@ use common::domain::{
     CreateEndDeviceDefinitionRepoInput, Device, EndDeviceDefinitionRepository, RawEnvelope,
     RawEnvelopeProducer as _,
 };
+use common::jsonschema::JsonSchemaValidator;
 use common::nats::{
     NatsClient, NatsConsumeLoggingLayer, NatsConsumeTracingConfig, NatsConsumeTracingLayer,
     TowerConsumer,
@@ -274,12 +275,16 @@ async fn initialize_services(
     // Payload converter
     let payload_converter = Arc::new(CelPayloadConverter::new());
 
+    // Schema validator
+    let schema_validator = Arc::new(JsonSchemaValidator::new());
+
     // Raw envelope service
     let raw_envelope_service = Arc::new(RawEnvelopeService::new(
         device_repo,
         org_repo,
         payload_converter,
         processed_producer,
+        schema_validator,
     ));
 
     Ok((

--- a/crates/ponix_api/src/domain/end_device_definition_service.rs
+++ b/crates/ponix_api/src/domain/end_device_definition_service.rs
@@ -2,9 +2,8 @@ use common::auth::{Action, AuthorizationProvider, Resource};
 use common::domain::{
     CreateEndDeviceDefinitionRepoInput, DeleteEndDeviceDefinitionRepoInput, DomainError,
     DomainResult, EndDeviceDefinition, EndDeviceDefinitionRepository,
-    GetEndDeviceDefinitionRepoInput, GetOrganizationRepoInput,
-    ListEndDeviceDefinitionsRepoInput, OrganizationRepository,
-    UpdateEndDeviceDefinitionRepoInput,
+    GetEndDeviceDefinitionRepoInput, GetOrganizationRepoInput, ListEndDeviceDefinitionsRepoInput,
+    OrganizationRepository, UpdateEndDeviceDefinitionRepoInput,
 };
 use common::jsonschema::validate_json_schema;
 use garde::Validate;
@@ -99,7 +98,7 @@ impl EndDeviceDefinitionService {
         &self,
         request: CreateEndDeviceDefinitionRequest,
     ) -> DomainResult<EndDeviceDefinition> {
-        common::garde::validate(&request)?;
+        common::garde::validate_struct(&request)?;
 
         // Validate JSON Schema syntax
         validate_json_schema(&request.json_schema)?;
@@ -140,7 +139,7 @@ impl EndDeviceDefinitionService {
         &self,
         request: GetEndDeviceDefinitionRequest,
     ) -> DomainResult<EndDeviceDefinition> {
-        common::garde::validate(&request)?;
+        common::garde::validate_struct(&request)?;
 
         self.authorization_provider
             .require_permission(
@@ -167,7 +166,7 @@ impl EndDeviceDefinitionService {
         &self,
         request: UpdateEndDeviceDefinitionRequest,
     ) -> DomainResult<EndDeviceDefinition> {
-        common::garde::validate(&request)?;
+        common::garde::validate_struct(&request)?;
 
         // Validate JSON Schema if provided
         if let Some(ref schema) = request.json_schema {
@@ -201,7 +200,7 @@ impl EndDeviceDefinitionService {
         &self,
         request: DeleteEndDeviceDefinitionRequest,
     ) -> DomainResult<()> {
-        common::garde::validate(&request)?;
+        common::garde::validate_struct(&request)?;
 
         self.authorization_provider
             .require_permission(
@@ -227,7 +226,7 @@ impl EndDeviceDefinitionService {
         &self,
         request: ListEndDeviceDefinitionsRequest,
     ) -> DomainResult<Vec<EndDeviceDefinition>> {
-        common::garde::validate(&request)?;
+        common::garde::validate_struct(&request)?;
 
         self.authorization_provider
             .require_permission(
@@ -278,7 +277,9 @@ impl EndDeviceDefinitionService {
 mod tests {
     use super::*;
     use common::auth::MockAuthorizationProvider;
-    use common::domain::{MockEndDeviceDefinitionRepository, MockOrganizationRepository, Organization};
+    use common::domain::{
+        MockEndDeviceDefinitionRepository, MockOrganizationRepository, Organization,
+    };
 
     const TEST_USER_ID: &str = "user-123";
 

--- a/crates/ponix_api/src/domain/end_device_service.rs
+++ b/crates/ponix_api/src/domain/end_device_service.rs
@@ -72,7 +72,7 @@ impl DeviceService {
     #[instrument(skip(self, request), fields(user_id = %request.user_id, organization_id = %request.organization_id, device_name = %request.name))]
     pub async fn create_device(&self, request: CreateDeviceRequest) -> DomainResult<Device> {
         // Validate request using garde
-        common::garde::validate(&request)?;
+        common::garde::validate_struct(&request)?;
 
         // Check authorization
         self.authorization_provider
@@ -147,7 +147,7 @@ impl DeviceService {
     #[instrument(skip(self, request), fields(user_id = %request.user_id, device_id = %request.device_id, organization_id = %request.organization_id))]
     pub async fn get_device(&self, request: GetDeviceRequest) -> DomainResult<Device> {
         // Validate request using garde
-        common::garde::validate(&request)?;
+        common::garde::validate_struct(&request)?;
 
         // Check authorization
         self.authorization_provider
@@ -179,7 +179,7 @@ impl DeviceService {
     #[instrument(skip(self, request), fields(user_id = %request.user_id, organization_id = %request.organization_id))]
     pub async fn list_devices(&self, request: ListDevicesRequest) -> DomainResult<Vec<Device>> {
         // Validate request using garde
-        common::garde::validate(&request)?;
+        common::garde::validate_struct(&request)?;
 
         // Check authorization
         self.authorization_provider

--- a/crates/ponix_api/src/domain/gateway_service.rs
+++ b/crates/ponix_api/src/domain/gateway_service.rs
@@ -91,7 +91,7 @@ impl GatewayService {
     #[instrument(skip(self, request), fields(user_id = %request.user_id, organization_id = %request.organization_id, gateway_type = %request.gateway_type))]
     pub async fn create_gateway(&self, request: CreateGatewayRequest) -> DomainResult<Gateway> {
         // Validate request using garde
-        common::garde::validate(&request)?;
+        common::garde::validate_struct(&request)?;
 
         debug!(organization_id = %request.organization_id, gateway_type = %request.gateway_type, "Creating gateway");
 
@@ -151,7 +151,7 @@ impl GatewayService {
     #[instrument(skip(self, request), fields(user_id = %request.user_id, gateway_id = %request.gateway_id, organization_id = %request.organization_id))]
     pub async fn get_gateway(&self, request: GetGatewayRequest) -> DomainResult<Gateway> {
         // Validate request using garde
-        common::garde::validate(&request)?;
+        common::garde::validate_struct(&request)?;
 
         debug!(gateway_id = %request.gateway_id, organization_id = %request.organization_id, "Getting gateway");
 
@@ -183,7 +183,7 @@ impl GatewayService {
     #[instrument(skip(self, request), fields(user_id = %request.user_id, gateway_id = %request.gateway_id, organization_id = %request.organization_id))]
     pub async fn update_gateway(&self, request: UpdateGatewayRequest) -> DomainResult<Gateway> {
         // Validate request using garde
-        common::garde::validate(&request)?;
+        common::garde::validate_struct(&request)?;
 
         debug!(gateway_id = %request.gateway_id, organization_id = %request.organization_id, "Updating gateway");
 
@@ -214,7 +214,7 @@ impl GatewayService {
     #[instrument(skip(self, request), fields(user_id = %request.user_id, gateway_id = %request.gateway_id, organization_id = %request.organization_id))]
     pub async fn delete_gateway(&self, request: DeleteGatewayRequest) -> DomainResult<()> {
         // Validate request using garde
-        common::garde::validate(&request)?;
+        common::garde::validate_struct(&request)?;
 
         debug!(gateway_id = %request.gateway_id, organization_id = %request.organization_id, "Deleting gateway");
 
@@ -243,7 +243,7 @@ impl GatewayService {
     #[instrument(skip(self, request), fields(user_id = %request.user_id, organization_id = %request.organization_id))]
     pub async fn list_gateways(&self, request: ListGatewaysRequest) -> DomainResult<Vec<Gateway>> {
         // Validate request using garde
-        common::garde::validate(&request)?;
+        common::garde::validate_struct(&request)?;
 
         debug!(organization_id = %request.organization_id, "Listing gateways");
 

--- a/crates/ponix_api/src/domain/organization_service.rs
+++ b/crates/ponix_api/src/domain/organization_service.rs
@@ -86,7 +86,7 @@ impl OrganizationService {
         request: CreateOrganizationRequest,
     ) -> DomainResult<Organization> {
         // Validate request using garde
-        common::garde::validate(&request)?;
+        common::garde::validate_struct(&request)?;
 
         debug!(name = %request.name, user_id = %request.user_id, "creating organization");
 
@@ -120,7 +120,7 @@ impl OrganizationService {
         request: GetOrganizationRequest,
     ) -> DomainResult<Organization> {
         // Validate request using garde
-        common::garde::validate(&request)?;
+        common::garde::validate_struct(&request)?;
 
         debug!(organization_id = %request.organization_id, "getting organization");
 
@@ -154,7 +154,7 @@ impl OrganizationService {
         request: UpdateOrganizationRequest,
     ) -> DomainResult<Organization> {
         // Validate request using garde
-        common::garde::validate(&request)?;
+        common::garde::validate_struct(&request)?;
 
         debug!(organization_id = %request.organization_id, "updating organization");
 
@@ -186,7 +186,7 @@ impl OrganizationService {
         request: DeleteOrganizationRequest,
     ) -> DomainResult<()> {
         // Validate request using garde
-        common::garde::validate(&request)?;
+        common::garde::validate_struct(&request)?;
 
         debug!(organization_id = %request.organization_id, "Deleting organization");
 
@@ -232,7 +232,7 @@ impl OrganizationService {
         request: GetUserOrganizationsRequest,
     ) -> DomainResult<Vec<Organization>> {
         // Validate request using garde
-        common::garde::validate(&request)?;
+        common::garde::validate_struct(&request)?;
 
         debug!(user_id = %request.user_id, "getting organizations for user");
 

--- a/crates/ponix_api/src/domain/user_service.rs
+++ b/crates/ponix_api/src/domain/user_service.rs
@@ -63,7 +63,7 @@ impl UserService {
     #[instrument(skip(self, request), fields(email = %request.email))]
     pub async fn register_user(&self, request: RegisterUserRequest) -> DomainResult<User> {
         // Validate request using garde
-        common::garde::validate(&request)?;
+        common::garde::validate_struct(&request)?;
 
         debug!(email = %request.email, "registering new user");
 
@@ -92,7 +92,7 @@ impl UserService {
     #[instrument(skip(self, request), fields(user_id = %request.user_id))]
     pub async fn get_user(&self, request: GetUserRequest) -> DomainResult<User> {
         // Validate request using garde
-        common::garde::validate(&request)?;
+        common::garde::validate_struct(&request)?;
 
         debug!(user_id = %request.user_id, "getting user");
 


### PR DESCRIPTION
## Summary
- Add JSON Schema validation for processed envelope data in the analytics worker
- Add garde validation to `DeviceWithDefinition` for `payload_conversion` and `json_schema` fields
- Refactor `SchemaValidator` trait to be generic (removed device_id parameter)
- Replace `MissingCelExpression` error with generic `ValidationError`

### Changes

**Domain Layer**
- Add `SchemaValidator` trait and `JsonSchemaValidator` implementation in `common/src/jsonschema/`
- Add garde validation to `DeviceWithDefinition` entity (both `payload_conversion` and `json_schema` must be non-empty)
- Remove `MissingCelExpression` error variant, consolidated to `ValidationError`

**Analytics Worker**
- Integrate `SchemaValidator` into `RawEnvelopeService`
- Add garde validation before CEL conversion
- Schema validation failures return `Ok()` (ACK'd) since retrying won't help
- Validation errors (empty payload_conversion/json_schema) return `Err()` (NAK'd)

**Tests**
- Update unit tests for new validation behavior
- Update integration tests with schema_validator parameter
- Update e2e test with schema_validator parameter

## Test plan
- [x] Unit tests pass (`cargo test --workspace --lib --bins`)
- [x] Build succeeds with integration-tests feature

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)