### PR TITLE
feat: multi-protocol payload contracts

### DIFF
--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -20,7 +20,7 @@ If the user provided an argument or context clues, map it to a variant. Otherwis
 | **all** | `mise run test:all` | Docker running |
 | **watch** | `mise run test:watch` | None — continuous unit test feedback |
 | **watch:integration** | `mise run test:integration:watch` | Docker running |
-| **e2e** | `mise run test:e2e` | Running service (`tilt up` or `docker-compose up`) |
+| **e2e** | `mise run test:e2e` | Running service — run `tilt ci` first to start the environment |
 
 **Argument mapping examples:**
 - `/test` → ask user or default to unit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3168,9 +3168,9 @@ dependencies = [
 
 [[package]]
 name = "ponix_ponix_community_neoeinstein-prost"
-version = "0.5.0-20260222204659-b3497abe97e6.2"
+version = "0.5.0-20260222230759-321a9c11336c.2"
 source = "sparse+https://buf.build/gen/cargo/"
-checksum = "f94b00df2257215fb6bd35c65d0af5ea3322d08751e158b929e0974724dcb006"
+checksum = "2ba489295c7a7b35e1a084e4bdf2c2ebf2ad0d3f283b6be2216bef120c6a91af"
 dependencies = [
  "prost 0.14.1",
  "prost-types",
@@ -3178,9 +3178,9 @@ dependencies = [
 
 [[package]]
 name = "ponix_ponix_community_neoeinstein-tonic"
-version = "0.5.0-20260222204659-b3497abe97e6.4"
+version = "0.5.0-20260222230759-321a9c11336c.4"
 source = "sparse+https://buf.build/gen/cargo/"
-checksum = "c3245fdd67676a31454504dfcb8527cb48333e2cc54c765d967f283285a79183"
+checksum = "dcd37794732d05be469ee12c047a0f4b0cc174b41c9907252feafdd0a6fbf10d"
 dependencies = [
  "ponix_ponix_community_neoeinstein-prost",
  "tonic 0.14.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,8 @@ http = "1.0"
 protoc-wkt = "1.0"
 
 # Protobuf (BSR registry)
-ponix-proto-prost = { package = "ponix_ponix_community_neoeinstein-prost", version = "0.5.0-20251203033831-5701e04c46e1.2", registry = "buf" }
-ponix-proto-tonic = { package = "ponix_ponix_community_neoeinstein-tonic", version = "0.5.0-20251203033831-5701e04c46e1.3", registry = "buf" }
+ponix-proto-prost = { package = "ponix_ponix_community_neoeinstein-prost", version = "0.5.0-20260222230759-321a9c11336c.2", registry = "buf" }
+ponix-proto-tonic = { package = "ponix_ponix_community_neoeinstein-tonic", version = "0.5.0-20260222230759-321a9c11336c.4", registry = "buf" }
 
 # Database clients
 clickhouse = { version = "0.14", features = ["lz4", "inserter", "chrono"] }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,7 @@ An agentic system that can observe device data, query historical context, consul
 Make the existing ingest path multi-protocol and production-grade before building on it.
 
 - [x] #36 — Device ownership validation before raw envelope publish
-- [ ] #122 — Multi-protocol payload contracts — devices aren't locked to one CEL expression
+- [x] #122 — Multi-protocol payload contracts — devices aren't locked to one CEL expression
 - [ ] #119 — Own the CEL runtime — ability to add IoT-specific functions
 - [ ] #120 — Pre-compiled CEL — removes per-message compilation cost at scale
 - [ ] #26 — RAKwireless decoder — broader hardware support

--- a/crates/analytics_worker/src/domain/payload_converter.rs
+++ b/crates/analytics_worker/src/domain/payload_converter.rs
@@ -8,7 +8,7 @@ use common::domain::DomainResult;
 /// - Return PayloadConversionError on failure
 #[cfg_attr(test, mockall::automock)]
 pub trait PayloadConverter: Send + Sync {
-    /// Convert binary payload to JSON using a CEL expression
+    /// Transform binary payload to JSON using a CEL expression
     ///
     /// # Arguments
     /// * `expression` - CEL expression string (e.g., "cayenne_lpp_decode(input)")
@@ -16,5 +16,15 @@ pub trait PayloadConverter: Send + Sync {
     ///
     /// # Returns
     /// JSON value as serde_json::Value on success
-    fn convert(&self, expression: &str, payload: &[u8]) -> DomainResult<serde_json::Value>;
+    fn transform(&self, expression: &str, payload: &[u8]) -> DomainResult<serde_json::Value>;
+
+    /// Evaluate a CEL match expression against a binary payload
+    ///
+    /// # Arguments
+    /// * `expression` - CEL expression that should return a boolean
+    /// * `payload` - Binary payload to evaluate against
+    ///
+    /// # Returns
+    /// true if the expression matches, false otherwise
+    fn evaluate_match(&self, expression: &str, payload: &[u8]) -> DomainResult<bool>;
 }

--- a/crates/analytics_worker/src/domain/raw_envelope_service.rs
+++ b/crates/analytics_worker/src/domain/raw_envelope_service.rs
@@ -1,8 +1,8 @@
 use crate::domain::PayloadConverter;
 use common::domain::{
     DeviceRepository, DomainError, DomainResult, GetDeviceWithDefinitionRepoInput,
-    GetOrganizationRepoInput, OrganizationRepository, ProcessedEnvelope, ProcessedEnvelopeProducer,
-    RawEnvelope,
+    GetOrganizationRepoInput, OrganizationRepository, PayloadContract, ProcessedEnvelope,
+    ProcessedEnvelopeProducer, RawEnvelope,
 };
 use common::garde::validate_struct;
 use common::jsonschema::SchemaValidator;
@@ -12,12 +12,11 @@ use tracing::{debug, error, instrument, warn};
 /// Domain service that orchestrates raw → processed envelope conversion
 ///
 /// Flow:
-/// 1. Fetch device to get CEL expression and JSON schema
+/// 1. Fetch device to get payload contracts
 /// 2. Validate organization is not deleted
-/// 3. Convert binary payload using CEL expression
-/// 4. Validate converted JSON against device's JSON Schema
-/// 5. Build ProcessedEnvelope from JSON + metadata
-/// 6. Publish via producer trait
+/// 3. Iterate contracts: match → transform → validate schema
+/// 4. Build ProcessedEnvelope from JSON + metadata
+/// 5. Publish via producer trait
 pub struct RawEnvelopeService {
     device_repository: Arc<dyn DeviceRepository>,
     organization_repository: Arc<dyn OrganizationRepository>,
@@ -44,7 +43,7 @@ impl RawEnvelopeService {
         }
     }
 
-    /// Process a raw envelope: fetch device, validate org, convert payload, publish result
+    /// Process a raw envelope: fetch device, validate org, run contracts, publish result
     #[instrument(skip(self), fields(device_id = %raw.end_device_id, organization_id = %raw.organization_id))]
     pub async fn process_raw_envelope(&self, raw: RawEnvelope) -> DomainResult<()> {
         debug!(
@@ -102,41 +101,17 @@ impl RawEnvelopeService {
         // 3. Validate device with definition using garde
         validate_struct(&device)?;
 
-        debug!(
-            device_id = %raw.end_device_id,
-            definition_id = %device.definition_id,
-            expression = %device.payload_conversion,
-            "converting payload with CEL expression"
-        );
+        // 4. Process contracts: match → transform → validate
+        let json_value =
+            match self.process_contracts(&device.contracts, &raw.payload, &raw.end_device_id)? {
+                Some(value) => value,
+                None => {
+                    // No contract matched or schema validation failed — ACK without publish
+                    return Ok(());
+                }
+            };
 
-        // 4. Convert binary payload using CEL expression from definition
-        let json_value = self
-            .payload_converter
-            .convert(&device.payload_conversion, &raw.payload)?;
-
-        // 5. Validate converted JSON against device's JSON Schema (if schema exists)
-        // TODO: Add metrics counter for schema validation attempts
-        // TODO: Consider dead-letter queue for failed envelopes
-
-        debug!(
-            device_id = %raw.end_device_id,
-            "validating converted payload against JSON Schema"
-        );
-        if let Err(validation_error) = self
-            .schema_validator
-            .validate(&device.json_schema, &json_value)
-        {
-            // Schema validation failures are expected errors - log and skip (ACK)
-            // The data doesn't match the schema, retrying won't help
-            warn!(
-                device_id = %raw.end_device_id,
-                reason = %validation_error.message,
-                "envelope failed JSON Schema validation, skipping"
-            );
-            return Ok(()); // Return Ok so message gets ACK'd
-        }
-
-        // 6. Convert JSON Value to Map
+        // 5. Convert JSON Value to Map
         let data = match json_value {
             serde_json::Value::Object(map) => map,
             _ => {
@@ -150,7 +125,7 @@ impl RawEnvelopeService {
             }
         };
 
-        // 7. Build ProcessedEnvelope with current timestamp
+        // 6. Build ProcessedEnvelope with current timestamp
         let processed_envelope = ProcessedEnvelope {
             organization_id: raw.organization_id.clone(),
             end_device_id: raw.end_device_id.clone(),
@@ -165,7 +140,7 @@ impl RawEnvelopeService {
             "successfully converted payload"
         );
 
-        // 8. Publish via producer trait
+        // 7. Publish via producer trait
         self.producer
             .publish_processed_envelope(&processed_envelope)
             .await?;
@@ -177,6 +152,82 @@ impl RawEnvelopeService {
         );
 
         Ok(())
+    }
+
+    /// Iterate through contracts in order: evaluate match → transform → validate schema
+    ///
+    /// Returns:
+    /// - `Ok(Some(value))` if a contract matched, transformed, and validated successfully
+    /// - `Ok(None)` if no contract matched, or a matched contract failed schema validation
+    /// - `Err(...)` if match evaluation or transform execution failed with an error
+    fn process_contracts(
+        &self,
+        contracts: &[PayloadContract],
+        payload: &[u8],
+        device_id: &str,
+    ) -> DomainResult<Option<serde_json::Value>> {
+        for (idx, contract) in contracts.iter().enumerate() {
+            debug!(
+                device_id = %device_id,
+                contract_index = idx,
+                match_expression = %contract.match_expression,
+                "evaluating contract match expression"
+            );
+
+            let matched = self
+                .payload_converter
+                .evaluate_match(&contract.match_expression, payload)?;
+
+            if !matched {
+                debug!(
+                    device_id = %device_id,
+                    contract_index = idx,
+                    "contract match expression returned false, trying next"
+                );
+                continue;
+            }
+
+            debug!(
+                device_id = %device_id,
+                contract_index = idx,
+                transform_expression = %contract.transform_expression,
+                "contract matched, transforming payload"
+            );
+
+            let json_value = self
+                .payload_converter
+                .transform(&contract.transform_expression, payload)?;
+
+            // Validate against contract's JSON Schema
+            debug!(
+                device_id = %device_id,
+                contract_index = idx,
+                "validating transformed payload against JSON Schema"
+            );
+            // A matching contract claims ownership of the payload. If schema validation
+            // fails, the message is dropped (Ok(None)) rather than trying the next contract.
+            if let Err(validation_error) = self
+                .schema_validator
+                .validate(&contract.json_schema, &json_value)
+            {
+                warn!(
+                    device_id = %device_id,
+                    contract_index = idx,
+                    reason = %validation_error.message,
+                    "envelope failed JSON Schema validation, skipping"
+                );
+                return Ok(None);
+            }
+
+            return Ok(Some(json_value));
+        }
+
+        warn!(
+            device_id = %device_id,
+            contract_count = contracts.len(),
+            "no contract matched the payload, skipping"
+        );
+        Ok(None)
     }
 }
 
@@ -190,16 +241,8 @@ mod tests {
     };
     use common::jsonschema::{MockSchemaValidator, SchemaValidationError};
 
-    #[tokio::test]
-    async fn test_process_raw_envelope_success() {
-        // Arrange
-        let mut mock_device_repo = MockDeviceRepository::new();
-        let mut mock_org_repo = MockOrganizationRepository::new();
-        let mut mock_converter = MockPayloadConverter::new();
-        let mut mock_producer = MockProcessedEnvelopeProducer::new();
-        let mut mock_schema_validator = MockSchemaValidator::new();
-
-        let device = DeviceWithDefinition {
+    fn make_device_with_contracts(contracts: Vec<PayloadContract>) -> DeviceWithDefinition {
+        DeviceWithDefinition {
             device_id: "device-123".to_string(),
             organization_id: "org-456".to_string(),
             workspace_id: "ws-123".to_string(),
@@ -207,26 +250,48 @@ mod tests {
             gateway_id: "gw-001".to_string(),
             definition_name: "Test Definition".to_string(),
             name: "Test Device".to_string(),
-            payload_conversion: "cayenne_lpp_decode(input)".to_string(),
-            json_schema: "{}".to_string(),
+            contracts,
             created_at: None,
             updated_at: None,
-        };
+        }
+    }
 
-        let org = Organization {
+    fn default_contracts() -> Vec<PayloadContract> {
+        vec![PayloadContract {
+            match_expression: "true".to_string(),
+            transform_expression: "cayenne_lpp_decode(input)".to_string(),
+            json_schema: "{}".to_string(),
+        }]
+    }
+
+    fn active_org() -> Organization {
+        Organization {
             id: "org-456".to_string(),
             name: "Test Org".to_string(),
             deleted_at: None,
             created_at: None,
             updated_at: None,
-        };
+        }
+    }
 
-        let raw_envelope = RawEnvelope {
+    fn raw_envelope() -> RawEnvelope {
+        RawEnvelope {
             organization_id: "org-456".to_string(),
             end_device_id: "device-123".to_string(),
             received_at: chrono::Utc::now(),
-            payload: vec![0x01, 0x67, 0x01, 0x10], // Cayenne LPP temperature
-        };
+            payload: vec![0x01, 0x67, 0x01, 0x10],
+        }
+    }
+
+    #[tokio::test]
+    async fn test_process_raw_envelope_success() {
+        let mut mock_device_repo = MockDeviceRepository::new();
+        let mut mock_org_repo = MockOrganizationRepository::new();
+        let mut mock_converter = MockPayloadConverter::new();
+        let mut mock_producer = MockProcessedEnvelopeProducer::new();
+        let mut mock_schema_validator = MockSchemaValidator::new();
+
+        let device = make_device_with_contracts(default_contracts());
 
         mock_device_repo
             .expect_get_device_with_definition()
@@ -240,7 +305,7 @@ mod tests {
             .expect_get_organization()
             .withf(|input: &GetOrganizationRepoInput| input.organization_id == "org-456")
             .times(1)
-            .return_once(move |_| Ok(Some(org)));
+            .return_once(move |_| Ok(Some(active_org())));
 
         let mut expected_json = serde_json::Map::new();
         expected_json.insert(
@@ -249,7 +314,13 @@ mod tests {
         );
 
         mock_converter
-            .expect_convert()
+            .expect_evaluate_match()
+            .withf(|expr: &str, _payload: &[u8]| expr == "true")
+            .times(1)
+            .return_once(|_, _| Ok(true));
+
+        mock_converter
+            .expect_transform()
             .withf(|expr: &str, _payload: &[u8]| expr == "cayenne_lpp_decode(input)")
             .times(1)
             .return_once(move |_, _| Ok(serde_json::Value::Object(expected_json)));
@@ -277,16 +348,12 @@ mod tests {
             Arc::new(mock_schema_validator),
         );
 
-        // Act
-        let result = service.process_raw_envelope(raw_envelope).await;
-
-        // Assert
+        let result = service.process_raw_envelope(raw_envelope()).await;
         assert!(result.is_ok());
     }
 
     #[tokio::test]
     async fn test_process_raw_envelope_device_not_found() {
-        // Arrange
         let mut mock_device_repo = MockDeviceRepository::new();
         let mock_org_repo = MockOrganizationRepository::new();
         let mock_converter = MockPayloadConverter::new();
@@ -306,50 +373,28 @@ mod tests {
             Arc::new(mock_schema_validator),
         );
 
-        let raw_envelope = RawEnvelope {
-            organization_id: "org-456".to_string(),
-            end_device_id: "device-999".to_string(),
-            received_at: chrono::Utc::now(),
-            payload: vec![0x01, 0x67, 0x01, 0x10],
-        };
+        let result = service
+            .process_raw_envelope(RawEnvelope {
+                organization_id: "org-456".to_string(),
+                end_device_id: "device-999".to_string(),
+                received_at: chrono::Utc::now(),
+                payload: vec![0x01, 0x67, 0x01, 0x10],
+            })
+            .await;
 
-        // Act
-        let result = service.process_raw_envelope(raw_envelope).await;
-
-        // Assert
         assert!(matches!(result, Err(DomainError::DeviceNotFound(_))));
     }
 
     #[tokio::test]
-    async fn test_process_raw_envelope_missing_cel_expression() {
-        // Arrange
+    async fn test_process_raw_envelope_empty_contracts_returns_validation_error() {
+        // Empty contracts vec fails garde validation (length min = 1)
         let mut mock_device_repo = MockDeviceRepository::new();
         let mut mock_org_repo = MockOrganizationRepository::new();
         let mock_converter = MockPayloadConverter::new();
         let mock_producer = MockProcessedEnvelopeProducer::new();
         let mock_schema_validator = MockSchemaValidator::new();
 
-        let device = DeviceWithDefinition {
-            device_id: "device-123".to_string(),
-            organization_id: "org-456".to_string(),
-            workspace_id: "ws-123".to_string(),
-            definition_id: "def-789".to_string(),
-            gateway_id: "gw-001".to_string(),
-            definition_name: "Test Definition".to_string(),
-            name: "Test Device".to_string(),
-            payload_conversion: "".to_string(), // Empty expression
-            json_schema: "{}".to_string(),
-            created_at: None,
-            updated_at: None,
-        };
-
-        let org = Organization {
-            id: "org-456".to_string(),
-            name: "Test Org".to_string(),
-            deleted_at: None,
-            created_at: None,
-            updated_at: None,
-        };
+        let device = make_device_with_contracts(vec![]); // Empty contracts
 
         mock_device_repo
             .expect_get_device_with_definition()
@@ -359,7 +404,7 @@ mod tests {
         mock_org_repo
             .expect_get_organization()
             .times(1)
-            .return_once(move |_| Ok(Some(org)));
+            .return_once(move |_| Ok(Some(active_org())));
 
         let service = RawEnvelopeService::new(
             Arc::new(mock_device_repo),
@@ -369,50 +414,23 @@ mod tests {
             Arc::new(mock_schema_validator),
         );
 
-        let raw_envelope = RawEnvelope {
-            organization_id: "org-456".to_string(),
-            end_device_id: "device-123".to_string(),
-            received_at: chrono::Utc::now(),
-            payload: vec![0x01, 0x67, 0x01, 0x10],
-        };
-
-        // Act
-        let result = service.process_raw_envelope(raw_envelope).await;
-
-        // Assert - garde validates that payload_conversion is non-empty
+        let result = service.process_raw_envelope(raw_envelope()).await;
         assert!(matches!(result, Err(DomainError::ValidationError(_))));
     }
 
     #[tokio::test]
     async fn test_process_raw_envelope_conversion_error() {
-        // Arrange
         let mut mock_device_repo = MockDeviceRepository::new();
         let mut mock_org_repo = MockOrganizationRepository::new();
         let mut mock_converter = MockPayloadConverter::new();
         let mock_producer = MockProcessedEnvelopeProducer::new();
         let mock_schema_validator = MockSchemaValidator::new();
 
-        let device = DeviceWithDefinition {
-            device_id: "device-123".to_string(),
-            organization_id: "org-456".to_string(),
-            workspace_id: "ws-123".to_string(),
-            definition_id: "def-789".to_string(),
-            gateway_id: "gw-001".to_string(),
-            definition_name: "Test Definition".to_string(),
-            name: "Test Device".to_string(),
-            payload_conversion: "invalid_expression".to_string(),
+        let device = make_device_with_contracts(vec![PayloadContract {
+            match_expression: "true".to_string(),
+            transform_expression: "invalid_expression".to_string(),
             json_schema: "{}".to_string(),
-            created_at: None,
-            updated_at: None,
-        };
-
-        let org = Organization {
-            id: "org-456".to_string(),
-            name: "Test Org".to_string(),
-            deleted_at: None,
-            created_at: None,
-            updated_at: None,
-        };
+        }]);
 
         mock_device_repo
             .expect_get_device_with_definition()
@@ -422,10 +440,15 @@ mod tests {
         mock_org_repo
             .expect_get_organization()
             .times(1)
-            .return_once(move |_| Ok(Some(org)));
+            .return_once(move |_| Ok(Some(active_org())));
 
         mock_converter
-            .expect_convert()
+            .expect_evaluate_match()
+            .times(1)
+            .return_once(|_, _| Ok(true));
+
+        mock_converter
+            .expect_transform()
             .times(1)
             .return_once(|_, _| {
                 Err(DomainError::PayloadConversionError(
@@ -441,17 +464,7 @@ mod tests {
             Arc::new(mock_schema_validator),
         );
 
-        let raw_envelope = RawEnvelope {
-            organization_id: "org-456".to_string(),
-            end_device_id: "device-123".to_string(),
-            received_at: chrono::Utc::now(),
-            payload: vec![0x01, 0x67, 0x01, 0x10],
-        };
-
-        // Act
-        let result = service.process_raw_envelope(raw_envelope).await;
-
-        // Assert
+        let result = service.process_raw_envelope(raw_envelope()).await;
         assert!(matches!(
             result,
             Err(DomainError::PayloadConversionError(_))
@@ -460,34 +473,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_process_raw_envelope_non_object_json() {
-        // Arrange
         let mut mock_device_repo = MockDeviceRepository::new();
         let mut mock_org_repo = MockOrganizationRepository::new();
         let mut mock_converter = MockPayloadConverter::new();
         let mock_producer = MockProcessedEnvelopeProducer::new();
         let mut mock_schema_validator = MockSchemaValidator::new();
 
-        let device = DeviceWithDefinition {
-            device_id: "device-123".to_string(),
-            organization_id: "org-456".to_string(),
-            workspace_id: "ws-123".to_string(),
-            definition_id: "def-789".to_string(),
-            gateway_id: "gw-001".to_string(),
-            definition_name: "Test Definition".to_string(),
-            name: "Test Device".to_string(),
-            payload_conversion: "42".to_string(), // Returns number, not object
+        let device = make_device_with_contracts(vec![PayloadContract {
+            match_expression: "true".to_string(),
+            transform_expression: "42".to_string(),
             json_schema: "{}".to_string(),
-            created_at: None,
-            updated_at: None,
-        };
-
-        let org = Organization {
-            id: "org-456".to_string(),
-            name: "Test Org".to_string(),
-            deleted_at: None,
-            created_at: None,
-            updated_at: None,
-        };
+        }]);
 
         mock_device_repo
             .expect_get_device_with_definition()
@@ -497,14 +493,18 @@ mod tests {
         mock_org_repo
             .expect_get_organization()
             .times(1)
-            .return_once(move |_| Ok(Some(org)));
+            .return_once(move |_| Ok(Some(active_org())));
 
         mock_converter
-            .expect_convert()
+            .expect_evaluate_match()
+            .times(1)
+            .return_once(|_, _| Ok(true));
+
+        mock_converter
+            .expect_transform()
             .times(1)
             .return_once(|_, _| Ok(serde_json::Value::Number(42.into())));
 
-        // Schema validation is called before the object type check
         mock_schema_validator
             .expect_validate()
             .times(1)
@@ -518,17 +518,7 @@ mod tests {
             Arc::new(mock_schema_validator),
         );
 
-        let raw_envelope = RawEnvelope {
-            organization_id: "org-456".to_string(),
-            end_device_id: "device-123".to_string(),
-            received_at: chrono::Utc::now(),
-            payload: vec![0x01, 0x67, 0x01, 0x10],
-        };
-
-        // Act
-        let result = service.process_raw_envelope(raw_envelope).await;
-
-        // Assert
+        let result = service.process_raw_envelope(raw_envelope()).await;
         assert!(matches!(
             result,
             Err(DomainError::PayloadConversionError(_))
@@ -537,34 +527,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_process_raw_envelope_publish_error() {
-        // Arrange
         let mut mock_device_repo = MockDeviceRepository::new();
         let mut mock_org_repo = MockOrganizationRepository::new();
         let mut mock_converter = MockPayloadConverter::new();
         let mut mock_producer = MockProcessedEnvelopeProducer::new();
         let mut mock_schema_validator = MockSchemaValidator::new();
 
-        let device = DeviceWithDefinition {
-            device_id: "device-123".to_string(),
-            organization_id: "org-456".to_string(),
-            workspace_id: "ws-123".to_string(),
-            definition_id: "def-789".to_string(),
-            gateway_id: "gw-001".to_string(),
-            definition_name: "Test Definition".to_string(),
-            name: "Test Device".to_string(),
-            payload_conversion: "cayenne_lpp_decode(input)".to_string(),
-            json_schema: "{}".to_string(),
-            created_at: None,
-            updated_at: None,
-        };
-
-        let org = Organization {
-            id: "org-456".to_string(),
-            name: "Test Org".to_string(),
-            deleted_at: None,
-            created_at: None,
-            updated_at: None,
-        };
+        let device = make_device_with_contracts(default_contracts());
 
         mock_device_repo
             .expect_get_device_with_definition()
@@ -574,7 +543,7 @@ mod tests {
         mock_org_repo
             .expect_get_organization()
             .times(1)
-            .return_once(move |_| Ok(Some(org)));
+            .return_once(move |_| Ok(Some(active_org())));
 
         let mut expected_json = serde_json::Map::new();
         expected_json.insert(
@@ -583,7 +552,12 @@ mod tests {
         );
 
         mock_converter
-            .expect_convert()
+            .expect_evaluate_match()
+            .times(1)
+            .return_once(|_, _| Ok(true));
+
+        mock_converter
+            .expect_transform()
             .times(1)
             .return_once(move |_, _| Ok(serde_json::Value::Object(expected_json)));
 
@@ -609,50 +583,20 @@ mod tests {
             Arc::new(mock_schema_validator),
         );
 
-        let raw_envelope = RawEnvelope {
-            organization_id: "org-456".to_string(),
-            end_device_id: "device-123".to_string(),
-            received_at: chrono::Utc::now(),
-            payload: vec![0x01, 0x67, 0x01, 0x10],
-        };
-
-        // Act
-        let result = service.process_raw_envelope(raw_envelope).await;
-
-        // Assert
+        let result = service.process_raw_envelope(raw_envelope()).await;
         assert!(matches!(result, Err(DomainError::RepositoryError(_))));
     }
 
     #[tokio::test]
     async fn test_process_raw_envelope_organization_deleted() {
-        // Arrange
         let mut mock_device_repo = MockDeviceRepository::new();
         let mut mock_org_repo = MockOrganizationRepository::new();
         let mock_converter = MockPayloadConverter::new();
         let mock_producer = MockProcessedEnvelopeProducer::new();
         let mock_schema_validator = MockSchemaValidator::new();
 
-        let device = DeviceWithDefinition {
-            device_id: "device-123".to_string(),
-            organization_id: "org-deleted".to_string(),
-            workspace_id: "ws-123".to_string(),
-            definition_id: "def-789".to_string(),
-            gateway_id: "gw-001".to_string(),
-            definition_name: "Test Definition".to_string(),
-            name: "Test Device".to_string(),
-            payload_conversion: "cayenne_lpp_decode(input)".to_string(),
-            json_schema: "{}".to_string(),
-            created_at: None,
-            updated_at: None,
-        };
-
-        let deleted_org = Organization {
-            id: "org-deleted".to_string(),
-            name: "Deleted Org".to_string(),
-            deleted_at: Some(chrono::Utc::now()),
-            created_at: None,
-            updated_at: None,
-        };
+        let mut device = make_device_with_contracts(default_contracts());
+        device.organization_id = "org-deleted".to_string();
 
         mock_device_repo
             .expect_get_device_with_definition()
@@ -663,7 +607,15 @@ mod tests {
             .expect_get_organization()
             .withf(|input: &GetOrganizationRepoInput| input.organization_id == "org-deleted")
             .times(1)
-            .return_once(move |_| Ok(Some(deleted_org)));
+            .return_once(move |_| {
+                Ok(Some(Organization {
+                    id: "org-deleted".to_string(),
+                    name: "Deleted Org".to_string(),
+                    deleted_at: Some(chrono::Utc::now()),
+                    created_at: None,
+                    updated_at: None,
+                }))
+            });
 
         let service = RawEnvelopeService::new(
             Arc::new(mock_device_repo),
@@ -673,42 +625,28 @@ mod tests {
             Arc::new(mock_schema_validator),
         );
 
-        let raw_envelope = RawEnvelope {
-            organization_id: "org-deleted".to_string(),
-            end_device_id: "device-123".to_string(),
-            received_at: chrono::Utc::now(),
-            payload: vec![0x01, 0x67, 0x01, 0x10],
-        };
+        let result = service
+            .process_raw_envelope(RawEnvelope {
+                organization_id: "org-deleted".to_string(),
+                end_device_id: "device-123".to_string(),
+                received_at: chrono::Utc::now(),
+                payload: vec![0x01, 0x67, 0x01, 0x10],
+            })
+            .await;
 
-        // Act
-        let result = service.process_raw_envelope(raw_envelope).await;
-
-        // Assert
         assert!(matches!(result, Err(DomainError::OrganizationDeleted(_))));
     }
 
     #[tokio::test]
     async fn test_process_raw_envelope_organization_not_found() {
-        // Arrange
         let mut mock_device_repo = MockDeviceRepository::new();
         let mut mock_org_repo = MockOrganizationRepository::new();
         let mock_converter = MockPayloadConverter::new();
         let mock_producer = MockProcessedEnvelopeProducer::new();
         let mock_schema_validator = MockSchemaValidator::new();
 
-        let device = DeviceWithDefinition {
-            device_id: "device-123".to_string(),
-            organization_id: "org-nonexistent".to_string(),
-            workspace_id: "ws-123".to_string(),
-            definition_id: "def-789".to_string(),
-            gateway_id: "gw-001".to_string(),
-            definition_name: "Test Definition".to_string(),
-            name: "Test Device".to_string(),
-            payload_conversion: "cayenne_lpp_decode(input)".to_string(),
-            json_schema: "{}".to_string(),
-            created_at: None,
-            updated_at: None,
-        };
+        let mut device = make_device_with_contracts(default_contracts());
+        device.organization_id = "org-nonexistent".to_string();
 
         mock_device_repo
             .expect_get_device_with_definition()
@@ -729,51 +667,31 @@ mod tests {
             Arc::new(mock_schema_validator),
         );
 
-        let raw_envelope = RawEnvelope {
-            organization_id: "org-nonexistent".to_string(),
-            end_device_id: "device-123".to_string(),
-            received_at: chrono::Utc::now(),
-            payload: vec![0x01, 0x67, 0x01, 0x10],
-        };
+        let result = service
+            .process_raw_envelope(RawEnvelope {
+                organization_id: "org-nonexistent".to_string(),
+                end_device_id: "device-123".to_string(),
+                received_at: chrono::Utc::now(),
+                payload: vec![0x01, 0x67, 0x01, 0x10],
+            })
+            .await;
 
-        // Act
-        let result = service.process_raw_envelope(raw_envelope).await;
-
-        // Assert
         assert!(matches!(result, Err(DomainError::OrganizationNotFound(_))));
     }
 
     #[tokio::test]
     async fn test_process_raw_envelope_schema_validation_failed_returns_ok() {
-        // Schema validation failures should return Ok() (message gets ACK'd, not retried)
-        // Arrange
         let mut mock_device_repo = MockDeviceRepository::new();
         let mut mock_org_repo = MockOrganizationRepository::new();
         let mut mock_converter = MockPayloadConverter::new();
         let mock_producer = MockProcessedEnvelopeProducer::new();
         let mut mock_schema_validator = MockSchemaValidator::new();
 
-        let device = DeviceWithDefinition {
-            device_id: "device-123".to_string(),
-            organization_id: "org-456".to_string(),
-            workspace_id: "ws-123".to_string(),
-            definition_id: "def-789".to_string(),
-            gateway_id: "gw-001".to_string(),
-            definition_name: "Test Definition".to_string(),
-            name: "Test Device".to_string(),
-            payload_conversion: "cayenne_lpp_decode(input)".to_string(),
+        let device = make_device_with_contracts(vec![PayloadContract {
+            match_expression: "true".to_string(),
+            transform_expression: "cayenne_lpp_decode(input)".to_string(),
             json_schema: r#"{"type": "object", "required": ["temperature"]}"#.to_string(),
-            created_at: None,
-            updated_at: None,
-        };
-
-        let org = Organization {
-            id: "org-456".to_string(),
-            name: "Test Org".to_string(),
-            deleted_at: None,
-            created_at: None,
-            updated_at: None,
-        };
+        }]);
 
         mock_device_repo
             .expect_get_device_with_definition()
@@ -783,18 +701,21 @@ mod tests {
         mock_org_repo
             .expect_get_organization()
             .times(1)
-            .return_once(move |_| Ok(Some(org)));
+            .return_once(move |_| Ok(Some(active_org())));
 
-        // CEL conversion succeeds but returns data missing required field
         let mut json_data = serde_json::Map::new();
         json_data.insert("humidity".to_string(), serde_json::Value::Number(60.into()));
 
         mock_converter
-            .expect_convert()
+            .expect_evaluate_match()
+            .times(1)
+            .return_once(|_, _| Ok(true));
+
+        mock_converter
+            .expect_transform()
             .times(1)
             .return_once(move |_, _| Ok(serde_json::Value::Object(json_data)));
 
-        // Schema validation fails
         mock_schema_validator
             .expect_validate()
             .times(1)
@@ -812,51 +733,23 @@ mod tests {
             Arc::new(mock_schema_validator),
         );
 
-        let raw_envelope = RawEnvelope {
-            organization_id: "org-456".to_string(),
-            end_device_id: "device-123".to_string(),
-            received_at: chrono::Utc::now(),
-            payload: vec![0x01, 0x68, 0x3C], // Some payload
-        };
-
-        // Act
-        let result = service.process_raw_envelope(raw_envelope).await;
-
-        // Assert - should return Ok because schema validation failures are logged and skipped
+        let result = service.process_raw_envelope(raw_envelope()).await;
         assert!(result.is_ok());
     }
 
     #[tokio::test]
-    async fn test_process_raw_envelope_empty_schema_returns_validation_error() {
-        // Empty schema "" fails garde validation and should return Err
-        // Arrange
+    async fn test_process_raw_envelope_no_contract_matches_returns_ok() {
         let mut mock_device_repo = MockDeviceRepository::new();
         let mut mock_org_repo = MockOrganizationRepository::new();
-        let mock_converter = MockPayloadConverter::new(); // Should not be called
-        let mock_producer = MockProcessedEnvelopeProducer::new(); // Should not be called
-        let mock_schema_validator = MockSchemaValidator::new(); // Should not be called
+        let mut mock_converter = MockPayloadConverter::new();
+        let mock_producer = MockProcessedEnvelopeProducer::new();
+        let mock_schema_validator = MockSchemaValidator::new();
 
-        let device = DeviceWithDefinition {
-            device_id: "device-123".to_string(),
-            organization_id: "org-456".to_string(),
-            workspace_id: "ws-123".to_string(),
-            definition_id: "def-789".to_string(),
-            gateway_id: "gw-001".to_string(),
-            definition_name: "Test Definition".to_string(),
-            name: "Test Device".to_string(),
-            payload_conversion: "cayenne_lpp_decode(input)".to_string(),
-            json_schema: "".to_string(), // Empty schema - fails garde validation
-            created_at: None,
-            updated_at: None,
-        };
-
-        let org = Organization {
-            id: "org-456".to_string(),
-            name: "Test Org".to_string(),
-            deleted_at: None,
-            created_at: None,
-            updated_at: None,
-        };
+        let device = make_device_with_contracts(vec![PayloadContract {
+            match_expression: "false".to_string(),
+            transform_expression: "cayenne_lpp_decode(input)".to_string(),
+            json_schema: "{}".to_string(),
+        }]);
 
         mock_device_repo
             .expect_get_device_with_definition()
@@ -866,7 +759,13 @@ mod tests {
         mock_org_repo
             .expect_get_organization()
             .times(1)
-            .return_once(move |_| Ok(Some(org)));
+            .return_once(move |_| Ok(Some(active_org())));
+
+        mock_converter
+            .expect_evaluate_match()
+            .withf(|expr: &str, _| expr == "false")
+            .times(1)
+            .return_once(|_, _| Ok(false));
 
         let service = RawEnvelopeService::new(
             Arc::new(mock_device_repo),
@@ -876,17 +775,86 @@ mod tests {
             Arc::new(mock_schema_validator),
         );
 
-        let raw_envelope = RawEnvelope {
-            organization_id: "org-456".to_string(),
-            end_device_id: "device-123".to_string(),
-            received_at: chrono::Utc::now(),
-            payload: vec![0x01, 0x67, 0x01, 0x10],
-        };
+        let result = service.process_raw_envelope(raw_envelope()).await;
+        assert!(result.is_ok());
+    }
 
-        // Act
-        let result = service.process_raw_envelope(raw_envelope).await;
+    #[tokio::test]
+    async fn test_process_raw_envelope_second_contract_matches() {
+        let mut mock_device_repo = MockDeviceRepository::new();
+        let mut mock_org_repo = MockOrganizationRepository::new();
+        let mut mock_converter = MockPayloadConverter::new();
+        let mut mock_producer = MockProcessedEnvelopeProducer::new();
+        let mut mock_schema_validator = MockSchemaValidator::new();
 
-        // Assert - garde validates that json_schema is non-empty
-        assert!(matches!(result, Err(DomainError::ValidationError(_))));
+        let device = make_device_with_contracts(vec![
+            PayloadContract {
+                match_expression: "false".to_string(),
+                transform_expression: "should_not_run".to_string(),
+                json_schema: "{}".to_string(),
+            },
+            PayloadContract {
+                match_expression: "true".to_string(),
+                transform_expression: "cayenne_lpp_decode(input)".to_string(),
+                json_schema: "{}".to_string(),
+            },
+        ]);
+
+        mock_device_repo
+            .expect_get_device_with_definition()
+            .times(1)
+            .return_once(move |_| Ok(Some(device)));
+
+        mock_org_repo
+            .expect_get_organization()
+            .times(1)
+            .return_once(move |_| Ok(Some(active_org())));
+
+        // First contract: match returns false
+        mock_converter
+            .expect_evaluate_match()
+            .withf(|expr: &str, _| expr == "false")
+            .times(1)
+            .return_once(|_, _| Ok(false));
+
+        // Second contract: match returns true
+        mock_converter
+            .expect_evaluate_match()
+            .withf(|expr: &str, _| expr == "true")
+            .times(1)
+            .return_once(|_, _| Ok(true));
+
+        let mut expected_json = serde_json::Map::new();
+        expected_json.insert(
+            "temperature_1".to_string(),
+            serde_json::Value::Number(serde_json::Number::from_f64(27.2).unwrap()),
+        );
+
+        mock_converter
+            .expect_transform()
+            .withf(|expr: &str, _| expr == "cayenne_lpp_decode(input)")
+            .times(1)
+            .return_once(move |_, _| Ok(serde_json::Value::Object(expected_json)));
+
+        mock_schema_validator
+            .expect_validate()
+            .times(1)
+            .returning(|_, _| Ok(()));
+
+        mock_producer
+            .expect_publish_processed_envelope()
+            .times(1)
+            .return_once(|_| Ok(()));
+
+        let service = RawEnvelopeService::new(
+            Arc::new(mock_device_repo),
+            Arc::new(mock_org_repo),
+            Arc::new(mock_converter),
+            Arc::new(mock_producer),
+            Arc::new(mock_schema_validator),
+        );
+
+        let result = service.process_raw_envelope(raw_envelope()).await;
+        assert!(result.is_ok());
     }
 }

--- a/crates/analytics_worker/tests/envelope_integration_test.rs
+++ b/crates/analytics_worker/tests/envelope_integration_test.rs
@@ -180,8 +180,11 @@ async fn test_full_conversion_flow_cayenne_lpp() {
         gateway_id: "gw-001".to_string(),
         definition_name: "Temperature Sensor Def".to_string(),
         name: "Temperature Sensor".to_string(),
-        payload_conversion: "cayenne_lpp_decode(input)".to_string(),
-        json_schema: "{}".to_string(),
+        contracts: vec![common::domain::PayloadContract {
+            match_expression: "true".to_string(),
+            transform_expression: "cayenne_lpp_decode(input)".to_string(),
+            json_schema: "{}".to_string(),
+        }],
         created_at: None,
         updated_at: None,
     };
@@ -247,7 +250,9 @@ async fn test_full_conversion_flow_custom_transformation() {
         gateway_id: "gw-001".to_string(),
         definition_name: "Multi Sensor Def".to_string(),
         name: "Multi Sensor".to_string(),
-        payload_conversion: r#"
+        contracts: vec![common::domain::PayloadContract {
+            match_expression: "true".to_string(),
+            transform_expression: r#"
             {
                 'temp_c': cayenne_lpp_decode(input).temperature_1,
                 'temp_f': cayenne_lpp_decode(input).temperature_1 * 9.0 / 5.0 + 32.0,
@@ -255,8 +260,9 @@ async fn test_full_conversion_flow_custom_transformation() {
                 'status': 'active'
             }
         "#
-        .to_string(),
-        json_schema: "{}".to_string(),
+            .to_string(),
+            json_schema: "{}".to_string(),
+        }],
         created_at: None,
         updated_at: None,
     };
@@ -362,8 +368,11 @@ async fn test_invalid_cel_expression() {
         gateway_id: "gw-001".to_string(),
         definition_name: "Broken Definition".to_string(),
         name: "Broken Sensor".to_string(),
-        payload_conversion: "invalid{[syntax".to_string(),
-        json_schema: "{}".to_string(),
+        contracts: vec![common::domain::PayloadContract {
+            match_expression: "true".to_string(),
+            transform_expression: "invalid{[syntax".to_string(),
+            json_schema: "{}".to_string(),
+        }],
         created_at: None,
         updated_at: None,
     };
@@ -424,8 +433,7 @@ async fn test_empty_cel_expression() {
         gateway_id: "gw-001".to_string(),
         definition_name: "Unconfigured Definition".to_string(),
         name: "Unconfigured Sensor".to_string(),
-        payload_conversion: "".to_string(),
-        json_schema: "{}".to_string(),
+        contracts: vec![], // Empty contracts - fails garde validation
         created_at: None,
         updated_at: None,
     };
@@ -466,7 +474,7 @@ async fn test_empty_cel_expression() {
     // Act
     let result = service.process_raw_envelope(raw_envelope).await;
 
-    // Assert - garde validates that payload_conversion is non-empty
+    // Assert - garde validates that contracts is non-empty
     assert!(result.is_err());
     assert!(matches!(
         result.unwrap_err(),
@@ -486,8 +494,11 @@ async fn test_cel_expression_returns_non_object() {
         gateway_id: "gw-001".to_string(),
         definition_name: "Scalar Definition".to_string(),
         name: "Scalar Sensor".to_string(),
-        payload_conversion: "42".to_string(), // Returns number, not object
-        json_schema: "{}".to_string(),
+        contracts: vec![common::domain::PayloadContract {
+            match_expression: "true".to_string(),
+            transform_expression: "42".to_string(), // Returns number, not object
+            json_schema: "{}".to_string(),
+        }],
         created_at: None,
         updated_at: None,
     };

--- a/crates/common/src/domain/end_device.rs
+++ b/crates/common/src/domain/end_device.rs
@@ -1,3 +1,4 @@
+use crate::domain::end_device_definition::PayloadContract;
 use crate::domain::result::DomainResult;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -36,9 +37,7 @@ pub struct DeviceWithDefinition {
     #[garde(skip)]
     pub name: String,
     #[garde(length(min = 1))]
-    pub payload_conversion: String,
-    #[garde(length(min = 1))]
-    pub json_schema: String,
+    pub contracts: Vec<PayloadContract>,
     #[garde(skip)]
     pub created_at: Option<DateTime<Utc>>,
     #[garde(skip)]
@@ -101,7 +100,7 @@ pub trait DeviceRepository: Send + Sync {
     async fn list_devices(&self, input: ListDevicesRepoInput) -> DomainResult<Vec<Device>>;
 
     /// Get a device with its definition data in a single query (JOIN)
-    /// Returns device info plus definition's payload_conversion and json_schema
+    /// Returns device info plus definition's protocol and contracts
     async fn get_device_with_definition(
         &self,
         input: GetDeviceWithDefinitionRepoInput,

--- a/crates/common/src/domain/end_device_definition.rs
+++ b/crates/common/src/domain/end_device_definition.rs
@@ -1,16 +1,24 @@
 use crate::domain::result::DomainResult;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// A single payload processing contract: match -> transform -> validate
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PayloadContract {
+    pub match_expression: String,
+    pub transform_expression: String,
+    pub json_schema: String,
+}
 
 /// Domain representation of an End Device Definition
-/// Contains JSON Schema for payload validation and payload conversion logic
+/// Contains ordered payload contracts for processing device data
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EndDeviceDefinition {
     pub id: String,
     pub organization_id: String,
     pub name: String,
-    pub json_schema: String,
-    pub payload_conversion: String,
+    pub contracts: Vec<PayloadContract>,
     pub created_at: Option<DateTime<Utc>>,
     pub updated_at: Option<DateTime<Utc>>,
 }
@@ -21,8 +29,7 @@ pub struct CreateEndDeviceDefinitionRepoInput {
     pub id: String,
     pub organization_id: String,
     pub name: String,
-    pub json_schema: String,
-    pub payload_conversion: String,
+    pub contracts: Vec<PayloadContract>,
 }
 
 /// Repository input for retrieving a definition
@@ -38,8 +45,7 @@ pub struct UpdateEndDeviceDefinitionRepoInput {
     pub id: String,
     pub organization_id: String,
     pub name: Option<String>,
-    pub json_schema: Option<String>,
-    pub payload_conversion: Option<String>,
+    pub contracts: Option<Vec<PayloadContract>>,
 }
 
 /// Repository input for deleting a definition

--- a/crates/common/tests/end_device_repository_integration.rs
+++ b/crates/common/tests/end_device_repository_integration.rs
@@ -111,8 +111,11 @@ async fn create_test_definition(
         id: def_id.clone(),
         organization_id: org_id.to_string(),
         name: "Test Definition".to_string(),
-        json_schema: "{}".to_string(),
-        payload_conversion: "cayenne_lpp_decode(input)".to_string(),
+        contracts: vec![common::domain::PayloadContract {
+            match_expression: "true".to_string(),
+            transform_expression: "cayenne_lpp_decode(input)".to_string(),
+            json_schema: "{}".to_string(),
+        }],
     };
     definition_repo.create_definition(input).await.unwrap();
     def_id
@@ -219,11 +222,11 @@ async fn test_get_device_with_definition() {
     assert_eq!(device_with_def.definition_id, definition_id);
     assert_eq!(device_with_def.gateway_id, gateway_id);
     assert_eq!(device_with_def.definition_name, "Test Definition");
+    assert_eq!(device_with_def.contracts.len(), 1);
     assert_eq!(
-        device_with_def.payload_conversion,
+        device_with_def.contracts[0].transform_expression,
         "cayenne_lpp_decode(input)"
     );
-    assert_eq!(device_with_def.json_schema, "{}");
 }
 
 #[tokio::test]
@@ -359,8 +362,11 @@ async fn test_get_device_with_wrong_organization_returns_none() {
         id: def_id.clone(),
         organization_id: "org-1".to_string(),
         name: "Definition for Org 1".to_string(),
-        json_schema: "{}".to_string(),
-        payload_conversion: "test".to_string(),
+        contracts: vec![common::domain::PayloadContract {
+            match_expression: "true".to_string(),
+            transform_expression: "test".to_string(),
+            json_schema: "{}".to_string(),
+        }],
     };
     definition_repo.create_definition(def_input).await.unwrap();
 

--- a/crates/init_process/migrations/postgres/20260222000000_add_protocol_and_contracts.sql
+++ b/crates/init_process/migrations/postgres/20260222000000_add_protocol_and_contracts.sql
@@ -1,0 +1,46 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Add contracts column as JSONB with default empty array
+ALTER TABLE end_device_definitions ADD COLUMN contracts JSONB NOT NULL DEFAULT '[]';
+
+-- Migrate existing data: wrap payload_conversion + json_schema into a single-element contracts array
+UPDATE end_device_definitions
+SET contracts = jsonb_build_array(
+    jsonb_build_object(
+        'match_expression', 'true',
+        'transform_expression', payload_conversion,
+        'json_schema', json_schema
+    )
+)
+WHERE payload_conversion IS NOT NULL AND payload_conversion != '';
+
+-- Enforce at least one contract at the database level
+ALTER TABLE end_device_definitions ADD CONSTRAINT contracts_non_empty CHECK (jsonb_array_length(contracts) > 0);
+
+-- Drop old columns
+ALTER TABLE end_device_definitions DROP COLUMN json_schema;
+ALTER TABLE end_device_definitions DROP COLUMN payload_conversion;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+-- Drop the non-empty constraint before reverting schema
+ALTER TABLE end_device_definitions DROP CONSTRAINT IF EXISTS contracts_non_empty;
+
+-- Re-add old columns
+ALTER TABLE end_device_definitions ADD COLUMN json_schema TEXT NOT NULL DEFAULT '{}';
+ALTER TABLE end_device_definitions ADD COLUMN payload_conversion TEXT NOT NULL DEFAULT '';
+
+-- Extract first contract back to flat fields
+UPDATE end_device_definitions
+SET json_schema = COALESCE(contracts->0->>'json_schema', '{}'),
+    payload_conversion = COALESCE(contracts->0->>'transform_expression', '')
+WHERE jsonb_array_length(contracts) > 0;
+
+-- Drop new columns
+ALTER TABLE end_device_definitions DROP COLUMN contracts;
+
+-- +goose StatementEnd

--- a/crates/ponix_all_in_one/tests/e2e_pipeline_test.rs
+++ b/crates/ponix_all_in_one/tests/e2e_pipeline_test.rs
@@ -345,8 +345,11 @@ async fn create_test_device(
             id: definition_id.clone(),
             organization_id: "test-org-123".to_string(),
             name: "Environmental Sensor Definition".to_string(),
-            json_schema: "{}".to_string(),
-            payload_conversion: cel_expression.to_string(),
+            contracts: vec![common::domain::PayloadContract {
+                match_expression: "true".to_string(),
+                transform_expression: cel_expression.to_string(),
+                json_schema: "{}".to_string(),
+            }],
         })
         .await?;
 

--- a/crates/ponix_api/src/domain/end_device_service.rs
+++ b/crates/ponix_api/src/domain/end_device_service.rs
@@ -367,8 +367,7 @@ mod tests {
             id: "def-789".to_string(),
             organization_id: "org-456".to_string(),
             name: "Test Definition".to_string(),
-            json_schema: "{}".to_string(),
-            payload_conversion: "cayenne_lpp.decode(payload)".to_string(),
+            contracts: vec![],
             created_at: None,
             updated_at: None,
         };

--- a/crates/ponix_api/src/domain/raw_envelope_ingestion_service.rs
+++ b/crates/ponix_api/src/domain/raw_envelope_ingestion_service.rs
@@ -88,6 +88,7 @@ mod tests {
     use common::domain::{DeviceWithDefinition, MockDeviceRepository, MockRawEnvelopeProducer};
 
     fn create_test_device() -> DeviceWithDefinition {
+        use common::domain::PayloadContract;
         DeviceWithDefinition {
             device_id: "device-123".to_string(),
             organization_id: "org-456".to_string(),
@@ -96,8 +97,11 @@ mod tests {
             gateway_id: "gw-001".to_string(),
             definition_name: "Test Definition".to_string(),
             name: "Test Device".to_string(),
-            payload_conversion: "cayenne_lpp_decode(input)".to_string(),
-            json_schema: "{}".to_string(),
+            contracts: vec![PayloadContract {
+                match_expression: "true".to_string(),
+                transform_expression: "cayenne_lpp_decode(input)".to_string(),
+                json_schema: "{}".to_string(),
+            }],
             created_at: None,
             updated_at: None,
         }

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -59,8 +59,9 @@ run_test "test-workspaces.sh" "Workspace Tests"
 run_test "test-devices.sh" "Device Tests"
 run_test "test-gateways.sh" "Gateway Tests"
 
-# MQTT pipeline test
+# MQTT pipeline tests
 run_test "test-mqtt-pipeline.sh" "MQTT Pipeline Test"
+run_test "test-multi-contract-pipeline.sh" "Multi-Contract Pipeline Test"
 
 # Summary
 echo -e "${BLUE}==========================================${NC}"

--- a/scripts/test-devices.sh
+++ b/scripts/test-devices.sh
@@ -73,8 +73,11 @@ DEFINITION_RESPONSE=$(grpc_call "$AUTH_TOKEN" \
     "{
         \"organization_id\": \"$ORG_ID\",
         \"name\": \"Cayenne LPP Temperature Sensor\",
-        \"json_schema\": \"{\\\"type\\\": \\\"object\\\"}\",
-        \"payload_conversion\": \"cayenne_lpp.decode(payload)\"
+        \"contracts\": [{
+            \"match_expression\": \"true\",
+            \"transform_expression\": \"cayenne_lpp_decode(input)\",
+            \"json_schema\": \"{\\\"type\\\": \\\"object\\\"}\"
+        }]
     }")
 
 DEFINITION_ID=$(echo "$DEFINITION_RESPONSE" | jq -r '.endDeviceDefinition.id // .id // empty')
@@ -111,8 +114,11 @@ UPDATE_DEFINITION_RESPONSE=$(grpc_call "$AUTH_TOKEN" \
         \"id\": \"$DEFINITION_ID\",
         \"organization_id\": \"$ORG_ID\",
         \"name\": \"Cayenne LPP Sensor - Updated\",
-        \"json_schema\": \"{\\\"type\\\": \\\"object\\\", \\\"description\\\": \\\"Updated\\\"}\",
-        \"payload_conversion\": \"cayenne_lpp.decode(payload)\"
+        \"contracts\": [{
+            \"match_expression\": \"true\",
+            \"transform_expression\": \"cayenne_lpp_decode(input)\",
+            \"json_schema\": \"{\\\"type\\\": \\\"object\\\", \\\"description\\\": \\\"Updated\\\"}\"
+        }]
     }")
 
 UPDATED_DEF_NAME=$(echo "$UPDATE_DEFINITION_RESPONSE" | jq -r '.endDeviceDefinition.name // .name // empty')
@@ -238,8 +244,11 @@ DEF2_RESPONSE=$(grpc_call "$AUTH_TOKEN" \
     "{
         \"organization_id\": \"$ORG_ID\",
         \"name\": \"Definition to Delete\",
-        \"json_schema\": \"{}\",
-        \"payload_conversion\": \"input\"
+        \"contracts\": [{
+            \"match_expression\": \"true\",
+            \"transform_expression\": \"input\",
+            \"json_schema\": \"{}\"
+        }]
     }")
 
 DEFINITION2_ID=$(echo "$DEF2_RESPONSE" | jq -r '.endDeviceDefinition.id // .id // empty')

--- a/scripts/test-mqtt-pipeline.sh
+++ b/scripts/test-mqtt-pipeline.sh
@@ -99,8 +99,11 @@ DEFINITION_RESPONSE=$(grpc_call "$AUTH_TOKEN" \
     "{
         \"organization_id\": \"$ORG_ID\",
         \"name\": \"Cayenne LPP Temperature Sensor\",
-        \"json_schema\": \"{}\",
-        \"payload_conversion\": \"cayenne_lpp_decode(input)\"
+        \"contracts\": [{
+            \"match_expression\": \"true\",
+            \"transform_expression\": \"cayenne_lpp_decode(input)\",
+            \"json_schema\": \"{}\"
+        }]
     }")
 
 DEFINITION_ID=$(echo "$DEFINITION_RESPONSE" | jq -r '.endDeviceDefinition.id // .id // empty')

--- a/scripts/test-multi-contract-pipeline.sh
+++ b/scripts/test-multi-contract-pipeline.sh
@@ -1,0 +1,316 @@
+#!/bin/bash
+set -euo pipefail
+
+# E2E Test: Multi-Contract Pipeline
+# Tests that a single device with two payload contracts correctly routes
+# messages based on payload size using first-match-wins semantics.
+#
+# Contract 1: size(input) == 4 → temp-only (4-byte Cayenne LPP)
+# Contract 2: size(input) == 7 → temp+humidity (7-byte Cayenne LPP)
+#
+# Prerequisites:
+#   - mqttx-cli (mise install)
+#   - grpcurl and jq installed
+#   - ponix service running (tilt up or docker-compose)
+#
+# Usage:
+#   ./scripts/test-multi-contract-pipeline.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/common.sh"
+
+# Additional configuration
+MQTT_HOST="${PONIX_MQTT_HOST:-localhost}"
+MQTT_PORT="${PONIX_MQTT_PORT:-1883}"
+GATEWAY_BROKER_URL="${PONIX_GATEWAY_BROKER_URL:-mqtt://ponix-emqx:1883}"
+CLICKHOUSE_CONTAINER="${PONIX_CLICKHOUSE_CONTAINER:-ponix-clickhouse}"
+CLICKHOUSE_USER="${PONIX_CLICKHOUSE_USERNAME:-ponix}"
+CLICKHOUSE_PASSWORD="${PONIX_CLICKHOUSE_PASSWORD:-ponix}"
+
+init_test_script "Multi-Contract Pipeline E2E Test"
+
+echo -e "${YELLOW}MQTT Configuration:${NC}"
+echo -e "  MQTT broker: ${MQTT_HOST}:${MQTT_PORT}"
+echo -e "  Gateway URL: ${GATEWAY_BROKER_URL}"
+echo ""
+
+# Check prerequisites
+require_command "mqttx-cli" "mise install"
+
+# ============================================
+# SETUP - Create all required resources
+# ============================================
+
+print_step "Setup: Authenticating..."
+setup_test_auth
+
+if [ -z "$AUTH_TOKEN" ] || [ "$AUTH_TOKEN" = "null" ]; then
+    print_error "Failed to authenticate"
+    exit 1
+fi
+print_success "Authenticated as $TEST_EMAIL"
+
+# Create Organization
+print_step "Setup: Creating organization..."
+ORG_RESPONSE=$(grpc_call "$AUTH_TOKEN" \
+    "organization.v1.OrganizationService/CreateOrganization" \
+    '{"name": "Multi-Contract Test Org"}')
+
+ORG_ID=$(echo "$ORG_RESPONSE" | jq -r '.organizationId // .organization.organizationId // empty')
+if [ -z "$ORG_ID" ] || [ "$ORG_ID" = "null" ]; then
+    print_error "Failed to create organization"
+    echo "$ORG_RESPONSE"
+    exit 1
+fi
+print_success "Organization: $ORG_ID"
+
+# Create Workspace
+print_step "Setup: Creating workspace..."
+WORKSPACE_RESPONSE=$(grpc_call "$AUTH_TOKEN" \
+    "workspace.v1.WorkspaceService/CreateWorkspace" \
+    "{\"organization_id\": \"$ORG_ID\", \"name\": \"Multi-Contract Test Workspace\"}")
+
+WORKSPACE_ID=$(echo "$WORKSPACE_RESPONSE" | jq -r '.workspace.id // .id // empty')
+if [ -z "$WORKSPACE_ID" ] || [ "$WORKSPACE_ID" = "null" ]; then
+    print_error "Failed to create workspace"
+    echo "$WORKSPACE_RESPONSE"
+    exit 1
+fi
+print_success "Workspace: $WORKSPACE_ID"
+
+# Create Gateway
+print_step "Setup: Creating MQTT gateway..."
+GATEWAY_RESPONSE=$(grpc_call "$AUTH_TOKEN" \
+    "gateway.v1.GatewayService/CreateGateway" \
+    "{
+        \"organization_id\": \"$ORG_ID\",
+        \"name\": \"Multi-Contract Test Gateway\",
+        \"type\": \"GATEWAY_TYPE_EMQX\",
+        \"emqx_config\": {
+            \"broker_url\": \"$GATEWAY_BROKER_URL\"
+        }
+    }")
+
+GATEWAY_ID=$(echo "$GATEWAY_RESPONSE" | jq -r '.gateway.gatewayId // .gatewayId // empty')
+if [ -z "$GATEWAY_ID" ] || [ "$GATEWAY_ID" = "null" ]; then
+    print_error "Failed to create gateway"
+    echo "$GATEWAY_RESPONSE"
+    exit 1
+fi
+print_success "Gateway: $GATEWAY_ID"
+
+# Create End Device Definition with TWO contracts
+print_step "Setup: Creating device definition with two contracts..."
+DEFINITION_RESPONSE=$(grpc_call "$AUTH_TOKEN" \
+    "end_device.v1.EndDeviceDefinitionService/CreateEndDeviceDefinition" \
+    "{
+        \"organization_id\": \"$ORG_ID\",
+        \"name\": \"Multi-Contract Sensor\",
+        \"contracts\": [
+            {
+                \"match_expression\": \"size(input) == 4\",
+                \"transform_expression\": \"cayenne_lpp_decode(input)\",
+                \"json_schema\": \"{}\"
+            },
+            {
+                \"match_expression\": \"size(input) == 7\",
+                \"transform_expression\": \"cayenne_lpp_decode(input)\",
+                \"json_schema\": \"{}\"
+            }
+        ]
+    }")
+
+DEFINITION_ID=$(echo "$DEFINITION_RESPONSE" | jq -r '.endDeviceDefinition.id // .id // empty')
+if [ -z "$DEFINITION_ID" ] || [ "$DEFINITION_ID" = "null" ]; then
+    print_error "Failed to create definition"
+    echo "$DEFINITION_RESPONSE"
+    exit 1
+fi
+print_success "Definition: $DEFINITION_ID (2 contracts)"
+
+# Create End Device
+print_step "Setup: Creating end device..."
+DEVICE_RESPONSE=$(grpc_call "$AUTH_TOKEN" \
+    "end_device.v1.EndDeviceService/CreateEndDevice" \
+    "{
+        \"organization_id\": \"$ORG_ID\",
+        \"workspace_id\": \"$WORKSPACE_ID\",
+        \"definition_id\": \"$DEFINITION_ID\",
+        \"gateway_id\": \"$GATEWAY_ID\",
+        \"name\": \"Multi-Contract Sensor\"
+    }")
+
+DEVICE_ID=$(echo "$DEVICE_RESPONSE" | jq -r '.endDevice.deviceId // .deviceId // empty')
+if [ -z "$DEVICE_ID" ] || [ "$DEVICE_ID" = "null" ]; then
+    print_error "Failed to create device"
+    echo "$DEVICE_RESPONSE"
+    exit 1
+fi
+print_success "Device: $DEVICE_ID"
+
+# ============================================
+# WAIT FOR GATEWAY CONNECTION
+# ============================================
+
+print_step "Waiting for gateway to connect to MQTT broker..."
+sleep 5
+
+# Send a warmup message to ensure the gateway subscription is active.
+# The CDC pipeline (postgres -> nats -> gateway orchestrator -> MQTT subscribe)
+# can take a few seconds; this sacrificial publish absorbs any remaining lag.
+mqttx-cli pub \
+    -h "${MQTT_HOST}" \
+    -p "${MQTT_PORT}" \
+    -t "${ORG_ID}/${DEVICE_ID}" \
+    -m "00" \
+    --format hex
+sleep 2
+print_success "Gateway connection window elapsed"
+
+# ============================================
+# PUBLISH TWO DIFFERENT MESSAGE TYPES
+# ============================================
+
+# Message type 1: temp-only (4 bytes)
+# Cayenne LPP: channel=01, type=67 (temp), value=00FF (25.5°C)
+PAYLOAD_TEMP_ONLY="016700FF"
+
+print_step "Publishing message type 1: temp-only (4 bytes)..."
+echo -e "  Topic: ${ORG_ID}/${DEVICE_ID}"
+echo -e "  Payload (hex): ${PAYLOAD_TEMP_ONLY}"
+echo -e "  Expected match: contract 1 (size(input) == 4)"
+echo -e "  Decoded: Temperature 25.5°C"
+
+mqttx-cli pub \
+    -h "${MQTT_HOST}" \
+    -p "${MQTT_PORT}" \
+    -t "${ORG_ID}/${DEVICE_ID}" \
+    -m "${PAYLOAD_TEMP_ONLY}" \
+    --format hex
+
+print_success "Message type 1 published (temp-only)"
+
+sleep 2
+
+# Message type 2: temp+humidity (7 bytes)
+# Cayenne LPP: channel=01 type=67 value=00FF (25.5°C) + channel=02 type=68 value=64 (50%)
+PAYLOAD_TEMP_HUMIDITY="016700FF026864"
+
+print_step "Publishing message type 2: temp+humidity (7 bytes)..."
+echo -e "  Topic: ${ORG_ID}/${DEVICE_ID}"
+echo -e "  Payload (hex): ${PAYLOAD_TEMP_HUMIDITY}"
+echo -e "  Expected match: contract 2 (size(input) == 7)"
+echo -e "  Decoded: Temperature 25.5°C, Humidity 50%"
+
+mqttx-cli pub \
+    -h "${MQTT_HOST}" \
+    -p "${MQTT_PORT}" \
+    -t "${ORG_ID}/${DEVICE_ID}" \
+    -m "${PAYLOAD_TEMP_HUMIDITY}" \
+    --format hex
+
+print_success "Message type 2 published (temp+humidity)"
+
+# ============================================
+# VERIFICATION - Query ClickHouse
+# ============================================
+
+print_step "Waiting for pipeline processing..."
+sleep 5
+
+print_step "Querying ClickHouse for processed envelopes..."
+
+QUERY="SELECT data FROM ponix.processed_envelopes WHERE end_device_id = '$DEVICE_ID' ORDER BY received_at FORMAT JSONEachRow"
+
+# Poll for results — the pipeline may take a few seconds to flush to ClickHouse
+MAX_ATTEMPTS=6
+ATTEMPT=0
+ROW_COUNT=0
+CH_RESULT=""
+
+while [ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ]; do
+    ((ATTEMPT++))
+    CH_RESULT=$(docker exec "$CLICKHOUSE_CONTAINER" clickhouse-client \
+        -u "$CLICKHOUSE_USER" --password "$CLICKHOUSE_PASSWORD" \
+        -q "$QUERY" 2>&1) || true
+
+    if [ -n "$CH_RESULT" ]; then
+        ROW_COUNT=$(echo "$CH_RESULT" | wc -l | tr -d ' ')
+        if [ "$ROW_COUNT" -ge 2 ]; then
+            break
+        fi
+    fi
+
+    if [ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ]; then
+        print_info "Attempt $ATTEMPT/$MAX_ATTEMPTS: found $ROW_COUNT rows, waiting..."
+        sleep 3
+    fi
+done
+
+if [ "$ROW_COUNT" -lt 2 ]; then
+    print_error "Expected 2 processed envelopes, found $ROW_COUNT after $MAX_ATTEMPTS attempts"
+    echo -e "${YELLOW}Results:${NC}"
+    echo "$CH_RESULT"
+    echo -e "${YELLOW}Debug: Check service logs with:${NC}"
+    echo "  docker logs ponix-all-in-one 2>&1 | grep $DEVICE_ID"
+    exit 1
+fi
+
+print_success "Found $ROW_COUNT processed envelopes"
+
+# Verify first row (temp-only) has temperature but no humidity
+FIRST_DATA=$(echo "$CH_RESULT" | head -1 | jq -r '.data')
+print_info "Row 1 data: $FIRST_DATA"
+
+if echo "$FIRST_DATA" | jq -e '.temperature_1' > /dev/null 2>&1; then
+    print_success "Row 1 has temperature data"
+else
+    print_error "Row 1 missing temperature data"
+    exit 1
+fi
+
+if echo "$FIRST_DATA" | jq -e '.humidity_2' > /dev/null 2>&1; then
+    print_error "Row 1 should NOT have humidity data (temp-only contract)"
+    exit 1
+else
+    print_success "Row 1 correctly has no humidity data"
+fi
+
+# Verify second row (temp+humidity) has both
+SECOND_DATA=$(echo "$CH_RESULT" | head -2 | tail -1 | jq -r '.data')
+print_info "Row 2 data: $SECOND_DATA"
+
+if echo "$SECOND_DATA" | jq -e '.temperature_1' > /dev/null 2>&1; then
+    print_success "Row 2 has temperature data"
+else
+    print_error "Row 2 missing temperature data"
+    exit 1
+fi
+
+if echo "$SECOND_DATA" | jq -e '.humidity_2' > /dev/null 2>&1; then
+    print_success "Row 2 has humidity data"
+else
+    print_error "Row 2 missing humidity data (should have temp+humidity)"
+    exit 1
+fi
+
+# ============================================
+# SUMMARY
+# ============================================
+
+echo ""
+echo -e "${BLUE}========================================${NC}"
+echo -e "${GREEN}Multi-Contract Pipeline Test PASSED${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo ""
+echo -e "${YELLOW}Verified:${NC}"
+echo -e "  - Contract 1 (size==4) matched temp-only payload → temperature data only"
+echo -e "  - Contract 2 (size==7) matched temp+humidity payload → both fields present"
+echo -e "  - First-match-wins routing works correctly"
+echo ""
+echo -e "${YELLOW}Resources Created:${NC}"
+echo -e "  Organization: $ORG_ID"
+echo -e "  Workspace:    $WORKSPACE_ID"
+echo -e "  Gateway:      $GATEWAY_ID"
+echo -e "  Definition:   $DEFINITION_ID (2 contracts)"
+echo -e "  Device:       $DEVICE_ID"


### PR DESCRIPTION
## Summary

Migrate device definitions from flat `payload_conversion` + `json_schema` fields to an ordered `Vec<PayloadContract>` with match/transform/validate semantics. Each contract carries a CEL match expression (evaluated in order), a transform expression, and a JSON Schema for output validation. The first matching contract claims ownership of the payload.

Closes #122

## Changes

- Add `PayloadContract` domain type with `match_expression`, `transform_expression`, and `json_schema` fields
- Add PostgreSQL migration: new `contracts` JSONB column with data migration from old flat fields, plus `contracts_non_empty` CHECK constraint
- Update `RawEnvelopeService` to iterate contracts in order: match → transform → validate schema
- Add `evaluate_match` to CEL converter for boolean match expression evaluation
- Update CDC converter with extracted `value_to_proto_contract` helper (deduplication)
- Update gRPC handler with protobuf ↔ domain contract mapping
- Add `#[garde(length(min = 1))]` validation on create request contracts field
- Add design-decision comments for protobuf empty-list semantics and match-claim-ownership behavior
- Update repository layers (PostgreSQL device + definition repos) for JSONB contracts
- Add multi-contract pipeline test script and update existing test scripts

## Type of Change

- [x] `feat`: New feature

## Test Plan

- [x] Unit tests pass (`mise run test:unit`) — 324 tests
- [x] Format check passes (`mise run fmt:check`)
- [x] Clippy check passes (`mise run clippy:check`)
- [ ] Integration tests pass (`mise run test:integration`) *(requires Docker)*

## Additional Context

This is the foundation for multi-protocol device support. Devices can now have multiple payload contracts with different match conditions, enabling protocol-agnostic processing where a single device definition can handle payloads from different firmware versions or encoding formats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)