### PR TITLE
feat: use GHCR ponix-postgres image in tests, CI, and local dev

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -33,8 +33,5 @@ jobs:
           shared-key: "rust-cache"
           cache-on-failure: true
 
-      - name: Build ponix-postgres image
-        run: docker build -t ponix-postgres:latest docker/postgres/
-
       - name: Run integration tests
         run: mise run test:integration

--- a/.github/workflows/ponix-postgres.yml
+++ b/.github/workflows/ponix-postgres.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           context: docker/postgres
           file: docker/postgres/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: ${{ inputs.push }}
           tags: |
             ghcr.io/ponix-dev/ponix-postgres:latest

--- a/crates/cdc_worker/tests/gateway_cdc_integration.rs
+++ b/crates/cdc_worker/tests/gateway_cdc_integration.rs
@@ -47,7 +47,7 @@ async fn setup_test_env() -> TestEnvironment {
         .try_init();
 
     // Start PostgreSQL container with logical replication enabled
-    let postgres = GenericImage::new("ponix-postgres", "latest")
+    let postgres = GenericImage::new("ghcr.io/ponix-dev/ponix-postgres", "latest")
         .with_wait_for(testcontainers::core::WaitFor::message_on_stderr(
             "database system is ready to accept connections",
         ))

--- a/crates/common/tests/authorization_integration.rs
+++ b/crates/common/tests/authorization_integration.rs
@@ -17,7 +17,7 @@ async fn setup_test_db() -> (
     CasbinAuthorizationService,
     PostgresClient,
 ) {
-    let postgres = GenericImage::new("ponix-postgres", "latest")
+    let postgres = GenericImage::new("ghcr.io/ponix-dev/ponix-postgres", "latest")
         .with_wait_for(testcontainers::core::WaitFor::message_on_stderr(
             "database system is ready to accept connections",
         ))
@@ -664,7 +664,7 @@ async fn test_member_cannot_update_organization() {
 #[tokio::test]
 #[cfg_attr(not(feature = "integration-tests"), ignore)]
 async fn test_role_persisted_in_database() {
-    let postgres = GenericImage::new("ponix-postgres", "latest")
+    let postgres = GenericImage::new("ghcr.io/ponix-dev/ponix-postgres", "latest")
         .with_wait_for(testcontainers::core::WaitFor::message_on_stderr(
             "database system is ready to accept connections",
         ))

--- a/crates/common/tests/data_stream_repository_integration.rs
+++ b/crates/common/tests/data_stream_repository_integration.rs
@@ -18,7 +18,7 @@ async fn setup_test_db() -> (
     PostgresDataStreamDefinitionRepository,
     PostgresClient,
 ) {
-    let postgres = GenericImage::new("ponix-postgres", "latest")
+    let postgres = GenericImage::new("ghcr.io/ponix-dev/ponix-postgres", "latest")
         .with_wait_for(testcontainers::core::WaitFor::message_on_stderr(
             "database system is ready to accept connections",
         ))

--- a/crates/common/tests/gateway_repository_integration.rs
+++ b/crates/common/tests/gateway_repository_integration.rs
@@ -22,7 +22,7 @@ async fn setup_test_db() -> (
     PostgresOrganizationRepository,
     PostgresClient,
 ) {
-    let postgres = GenericImage::new("ponix-postgres", "latest")
+    let postgres = GenericImage::new("ghcr.io/ponix-dev/ponix-postgres", "latest")
         .with_wait_for(testcontainers::core::WaitFor::message_on_stderr(
             "database system is ready to accept connections",
         ))

--- a/crates/common/tests/organization_repository_integration.rs
+++ b/crates/common/tests/organization_repository_integration.rs
@@ -18,7 +18,7 @@ async fn setup_test_db() -> (
     PostgresOrganizationRepository,
     PostgresClient,
 ) {
-    let postgres = GenericImage::new("ponix-postgres", "latest")
+    let postgres = GenericImage::new("ghcr.io/ponix-dev/ponix-postgres", "latest")
         .with_wait_for(testcontainers::core::WaitFor::message_on_stderr(
             "database system is ready to accept connections",
         ))

--- a/crates/ponix_all_in_one/tests/e2e_pipeline_test.rs
+++ b/crates/ponix_all_in_one/tests/e2e_pipeline_test.rs
@@ -139,7 +139,7 @@ async fn start_containers() -> Result<(
 )> {
     // Start containers in parallel
     let (postgres, clickhouse, nats) = tokio::join!(
-        GenericImage::new("ponix-postgres", "latest")
+        GenericImage::new("ghcr.io/ponix-dev/ponix-postgres", "latest")
             .with_wait_for(testcontainers::core::WaitFor::message_on_stderr(
                 "database system is ready to accept connections"
             ))

--- a/docker/docker-compose.deps.yaml
+++ b/docker/docker-compose.deps.yaml
@@ -40,9 +40,7 @@ services:
         hard: 262144
 
   postgres:
-    build:
-      context: ./postgres
-      dockerfile: Dockerfile
+    image: ghcr.io/ponix-dev/ponix-postgres:latest
     container_name: ponix-postgres
     environment:
       POSTGRES_USER: ponix


### PR DESCRIPTION
## Summary

Replace locally-built `ponix-postgres` image with `ghcr.io/ponix-dev/ponix-postgres` across all consumers — testcontainers, CI workflow, and Docker Compose. Also adds multi-platform (amd64/arm64) build support to the publish workflow.

Closes #162

## Changes

- Update all testcontainers `GenericImage` references from `ponix-postgres` to `ghcr.io/ponix-dev/ponix-postgres` (7 occurrences across 6 test files)
- Remove `docker build` step from CI integration tests workflow — testcontainers pulls from GHCR automatically
- Replace `build:` directive with `image: ghcr.io/ponix-dev/ponix-postgres:latest` in `docker-compose.deps.yaml`
- Add `platforms: linux/amd64,linux/arm64` to the ponix-postgres publish workflow for Apple Silicon support

## Type of Change

- [x] `chore`: Build process, dependencies, or tooling

## Test Plan

- [x] Unit tests pass (`mise run test:unit`)
- [x] Format check passes (`mise run fmt:check`)
- [x] Clippy check passes (`mise run clippy:check`)
- [ ] Integration tests pass (`mise run test:integration`) *(requires multi-arch image to be published first)*

## Additional Context

The GHCR image must be set to **public** visibility and rebuilt with multi-platform support before integration tests will pass. The multi-arch build change in `ponix-postgres.yml` will produce `linux/amd64` and `linux/arm64` manifests on the next publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)